### PR TITLE
Backport useful upstream changes (Guzzle, OrderStatuses, swatches, tax-rate ordering, CES-984)

### DIFF
--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -333,7 +333,6 @@ class Attributes implements ComponentInterface
         $attributeData['update_product_preview_image'] = 1;
         $attributeData['use_product_image_for_swatch'] = 0;
         $attributeData['optionvisual'] = $this->getOptionSwatch($attributeData, $attributeConfig['option']['values']);
-        $attributeData['defaultvisual'] = $this->getOptionDefaultVisual($attributeData);
         $attributeData['swatchvisual'] = $this->getOptionSwatchVisual($attributeData);
         $attribute->addData($attributeData);
         $attribute->save();
@@ -356,7 +355,6 @@ class Attributes implements ComponentInterface
         $attributeData['update_product_preview_image'] = 1;
         $attributeData['use_product_image_for_swatch'] = 0;
         $attributeData['optiontext'] = $this->getOptionSwatch($attributeData, $attributeConfig['option']['values']);
-        $attributeData['defaulttext'] = $this->getOptionDefaultText($attributeData);
         $attributeData['swatchtext'] = $this->getOptionSwatchText($attributeData);
         $attribute->addData($attributeData);
         $attribute->save();
@@ -404,16 +402,6 @@ class Attributes implements ComponentInterface
      * @param array $attributeData
      * @return array
      */
-    private function getOptionDefaultVisual(array $attributeData): array
-    {
-        $optionSwatch = $this->getOptionSwatchVisual($attributeData);
-        return [array_keys($optionSwatch['value'])[0]];
-    }
-
-    /**
-     * @param array $attributeData
-     * @return array
-     */
     private function getOptionSwatchText(array $attributeData): array
     {
         $optionSwatch = ['value' => []];
@@ -421,16 +409,6 @@ class Attributes implements ComponentInterface
             $optionSwatch['value'][$optionKey] = [$optionValue, ''];
         }
         return $optionSwatch;
-    }
-
-    /**
-     * @param array $attributeData
-     * @return array
-     */
-    private function getOptionDefaultText(array $attributeData): array
-    {
-        $optionSwatch = $this->getOptionSwatchText($attributeData);
-        return [array_keys($optionSwatch['value'])[0]];
     }
 
     /**

--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -9,6 +9,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Eav\Api\AttributeRepositoryInterface;
 use Magento\Eav\Setup\EavSetup;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)
@@ -39,6 +40,16 @@ class Attributes implements ComponentInterface
      * @var LoggerInterface
      */
     private $log;
+
+    /**
+     * @var \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory
+     */
+    protected $attrOptionCollectionFactory;
+
+    /**
+     * @var \Magento\Eav\Model\Config
+     */
+    protected $eavConfig;
 
     /**
      * @var array
@@ -90,19 +101,30 @@ class Attributes implements ComponentInterface
     protected $attributeExists = false;
 
     /**
+     * @var array
+     */
+    protected $swatchMap = [];
+
+    /**
      * Attributes constructor.
      * @param EavSetup $eavSetup
      * @param AttributeRepositoryInterface $attributeRepository
      * @param LoggerInterface $log
+     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory
+     * @param \Magento\Eav\Model\Config $eavConfig
      */
     public function __construct(
         EavSetup $eavSetup,
         AttributeRepositoryInterface $attributeRepository,
-        LoggerInterface $log
+        LoggerInterface $log,
+        \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory,
+        \Magento\Eav\Model\Config $eavConfig
     ) {
         $this->eavSetup = $eavSetup;
         $this->attributeRepository = $attributeRepository;
         $this->log = $log;
+        $this->attrOptionCollectionFactory = $attrOptionCollectionFactory;
+        $this->eavConfig = $eavConfig;
     }
 
     /**
@@ -150,7 +172,14 @@ class Attributes implements ComponentInterface
             if (isset($attributeConfig['product_types'])) {
                 $attributeConfig['apply_to'] = implode(',', $attributeConfig['product_types']);
             }
-
+            //swatch functionality
+            $swatch = false;
+            if (in_array($attributeConfig['input'], ['swatch_text', 'swatch_visual'])){
+                $swatch = $attributeConfig['input'];
+                $attributeConfig['input'] = 'select';
+                $this->swatchMap =  $attributeConfig['swatch'] ?? [];
+            }
+            //swatch functionality
             $this->eavSetup->addAttribute(
                 $this->entityTypeId,
                 $attributeCode,
@@ -161,6 +190,16 @@ class Attributes implements ComponentInterface
                 $this->log->logInfo(sprintf('Attribute %s updated.', $attributeCode));
                 return;
             }
+            //swatch functionality
+            if ($swatch) {
+                if ($swatch === 'swatch_text'){
+                    $this->convertToTextSwatch($attributeCode, $attributeConfig);
+                } else {
+                    $this->convertToVisualSwatch($attributeCode, $attributeConfig);
+
+                }
+            }
+            //swatch functionality
 
             $this->log->logInfo(sprintf('Attribute %s created.', $attributeCode));
         }
@@ -275,5 +314,155 @@ class Attributes implements ComponentInterface
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @param string $attributeName
+     * @param array $attributeConfig
+     * @return void
+     */
+    public function convertToVisualSwatch(string $attributeName, array $attributeConfig)
+    {
+        $attribute = $this->eavConfig->getAttribute('catalog_product', $attributeName);
+        if (!$attribute) {
+            return;
+        }
+        $attributeData['option'] = $this->addExistingOptions($attribute);
+        $attributeData['frontend_input'] = 'select';
+        $attributeData['swatch_input_type'] = 'visual';
+        $attributeData['update_product_preview_image'] = 1;
+        $attributeData['use_product_image_for_swatch'] = 0;
+        $attributeData['optionvisual'] = $this->getOptionSwatch($attributeData, $attributeConfig['option']['values']);
+        $attributeData['defaultvisual'] = $this->getOptionDefaultVisual($attributeData);
+        $attributeData['swatchvisual'] = $this->getOptionSwatchVisual($attributeData);
+        $attribute->addData($attributeData);
+        $attribute->save();
+    }
+
+    /**
+     * @param string $attributeName
+     * @param array $attributeConfig
+     * @return void
+     */
+    public function convertToTextSwatch(string $attributeName, array $attributeConfig)
+    {
+        $attribute = $this->eavConfig->getAttribute('catalog_product', $attributeName);
+        if (!$attribute) {
+            return;
+        }
+        $attributeData['option'] = $this->addExistingOptions($attribute);
+        $attributeData['frontend_input'] = 'select';
+        $attributeData['swatch_input_type'] = 'text';
+        $attributeData['update_product_preview_image'] = 1;
+        $attributeData['use_product_image_for_swatch'] = 0;
+        $attributeData['optiontext'] = $this->getOptionSwatch($attributeData, $attributeConfig['option']['values']);
+        $attributeData['defaulttext'] = $this->getOptionDefaultText($attributeData);
+        $attributeData['swatchtext'] = $this->getOptionSwatchText($attributeData);
+        $attribute->addData($attributeData);
+        $attribute->save();
+    }
+
+
+    /**
+     * @param array $attributeData
+     * @return array
+     */
+    private function getOptionSwatchVisual(array $attributeData): array
+    {
+        $optionSwatch = ['value' => []];
+        foreach ($attributeData['option'] as $optionKey => $optionValue) {
+            if (substr($optionValue, 0, 1) == '#' && strlen($optionValue) == 7) {
+                $optionSwatch['value'][$optionKey] = $optionValue;
+            } else if (!empty($this->swatchMap[$optionKey])) {
+                $optionSwatch['value'][$optionKey] = $this->swatchMap[$optionKey];
+            } else {
+                $optionSwatch['value'][$optionKey] = null;
+            }
+        }
+        return $optionSwatch;
+    }
+
+    /**
+     * @param array $attributeData
+     * @param array $attributeOptions
+     * @return array
+     */
+    protected function getOptionSwatch(array $attributeData, array $attributeOptions): array
+    {
+        $optionSwatch = ['order' => [], 'value' => [], 'delete' => []];
+        $i = 0;
+        foreach ($attributeData['option'] as $optionKey => $optionValue) {
+            $label = array_search($optionValue, $attributeOptions) ?? $optionValue;
+            $optionSwatch['delete'][$optionKey] = '';
+            $optionSwatch['order'][$optionKey] = (string)$i++;
+            $optionSwatch['value'][$optionKey] = [$label, ''];
+        }
+        return $optionSwatch;
+    }
+
+    /**
+     * @param array $attributeData
+     * @return array
+     */
+    private function getOptionDefaultVisual(array $attributeData): array
+    {
+        $optionSwatch = $this->getOptionSwatchVisual($attributeData);
+        return [array_keys($optionSwatch['value'])[0]];
+    }
+
+    /**
+     * @param array $attributeData
+     * @return array
+     */
+    private function getOptionSwatchText(array $attributeData): array
+    {
+        $optionSwatch = ['value' => []];
+        foreach ($attributeData['option'] as $optionKey => $optionValue) {
+            $optionSwatch['value'][$optionKey] = [$optionValue, ''];
+        }
+        return $optionSwatch;
+    }
+
+    /**
+     * @param array $attributeData
+     * @return array
+     */
+    private function getOptionDefaultText(array $attributeData): array
+    {
+        $optionSwatch = $this->getOptionSwatchText($attributeData);
+        return [array_keys($optionSwatch['value'])[0]];
+    }
+
+    /**
+     * @param $attributeId
+     * @return void
+     */
+    private function loadOptionCollection($attributeId)
+    {
+        if (empty($this->optionCollection[$attributeId])) {
+            $this->optionCollection[$attributeId] = $this->attrOptionCollectionFactory->create()
+                ->setAttributeFilter($attributeId)
+                ->setPositionOrder('asc', true)
+                ->load();
+        }
+    }
+
+    /**
+     * @param Attribute $attribute
+     * @return array
+     */
+    private function addExistingOptions(Attribute $attribute): array
+    {
+        $options = [];
+        $attributeId = $attribute->getId();
+        if ($attributeId) {
+            $this->loadOptionCollection($attributeId);
+            /** @var \Magento\Eav\Model\Entity\Attribute\Option $option */
+            foreach ($this->optionCollection[$attributeId] as $option) {
+                $options[$option->getId()] = $option->getValue();
+            }
+        }
+
+        return $options;
     }
 }

--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -106,6 +106,11 @@ class Attributes implements ComponentInterface
     protected $swatchMap = [];
 
     /**
+     * @var array
+     */
+    protected $optionCollection = [];
+
+    /**
      * Attributes constructor.
      * @param EavSetup $eavSetup
      * @param AttributeRepositoryInterface $attributeRepository

--- a/Component/CustomerGroups.php
+++ b/Component/CustomerGroups.php
@@ -60,9 +60,8 @@ class CustomerGroups implements ComponentInterface
             if ($taxClassId) {
                 foreach ($taxClass['groups'] as $group) {
                     try {
-                        if (isset($group['name'])) {
-                            $this->createCustomerGroup($group['name'], $taxClassId);
-                        }
+                        $this->validateGroupName($group);
+                        $this->createCustomerGroup($group['name'], $taxClassId);
                     } catch (ComponentException $e) {
                         $this->log->logError($e->getMessage());
                     }
@@ -98,6 +97,26 @@ class CustomerGroups implements ComponentInterface
         $this->log->logInfo(
             sprintf('Customer Group "%s" created', $groupName)
         );
+    }
+
+    /**
+     * perform customer group name validation
+     *
+     * @param array $group
+     * @return null
+     * @throw ComponentException
+     */
+    private function validateGroupName(array $group)
+    {
+        if (!isset($group['name'])) {
+            throw new ComponentException(__('The customer group name is mandatory'));
+        }
+
+        if (strlen($group['name'])>32) {
+            throw new ComponentException(
+                __('The customer group name "%1" is too long (maximum length is 32 characters)', $group['name'])
+            );
+        }
     }
 
     /**

--- a/Component/OrderStatuses.php
+++ b/Component/OrderStatuses.php
@@ -1,0 +1,114 @@
+<?php
+namespace CtiDigital\Configurator\Component;
+
+use CtiDigital\Configurator\Api\ComponentInterface;
+use CtiDigital\Configurator\Api\LoggerInterface;
+use CtiDigital\Configurator\Exception\ComponentException;
+use Magento\Sales\Model\Order\Status;
+use Magento\Sales\Model\Order\StatusFactory;
+use Magento\Sales\Model\ResourceModel\Order\Status as StatusResource;
+use Magento\Sales\Model\ResourceModel\Order\StatusFactory as StatusResourceFactory;
+
+/**
+ * Class OrderStatuses
+ * @package CtiDigital\Configurator\Component
+ */
+class OrderStatuses implements ComponentInterface
+{
+    protected $alias = 'order_statuses';
+    protected $name = 'Order Statuses';
+    protected $description = 'Component to create custom order statuses';
+
+    /**
+     * @var StatusFactory
+     */
+    protected $statusFactory;
+
+    /**
+     * @var StatusResourceFactory
+     */
+    protected $statusResourceFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $log;
+
+    /**
+     * OrderStatuses constructor.
+     * @param StatusFactory $statusFactory
+     * @param StatusResourceFactory $statusResourceFactory
+     * @param LoggerInterface $log
+     */
+    public function __construct(
+        StatusFactory $statusFactory,
+        StatusResourceFactory $statusResourceFactory,
+        LoggerInterface $log
+    ) {
+        $this->statusFactory = $statusFactory;
+        $this->statusResourceFactory = $statusResourceFactory;
+        $this->log = $log;
+    }
+
+    /**
+     * @param $data
+     */
+    public function execute($data = null)
+    {
+        if (isset($data['order_statuses'])) {
+            foreach ($data['order_statuses'] as $statusSet) {
+                try {
+                    $this->createOrderStatuses($statusSet);
+                } catch (ComponentException $e) {
+                    $this->log->logError($e->getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $statusSet
+     * @throws \Magento\Framework\Exception\AlreadyExistsException
+     */
+    public function createOrderStatuses($statusSet)
+    {
+        foreach ($statusSet['statuses'] as $statusData) {
+            /** @var StatusResource $statusResource */
+            $statusResource = $this->statusResourceFactory->create();
+            /** @var Status $status */
+            $status = $this->statusFactory->create();
+            $status->setData([
+                'status' => $statusData['code'],
+                'label' => $statusData['name'],
+            ]);
+
+            try {
+                $statusResource->save($status);
+            } catch (ComponentException $e) {
+                $this->log->logError($e->getMessage());
+            }
+
+            $status->assignState($statusSet['state'], false, true);
+
+            $this->log->logInfo(
+                sprintf('Order status %s created', $statusData['name'])
+            );
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/Component/Product/Image.php
+++ b/Component/Product/Image.php
@@ -8,6 +8,7 @@ use FireGento\FastSimpleImport\Model\Config;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientFactory;
 use GuzzleHttp\Exception\GuzzleException;
+use Magento\Framework\Webapi\Rest\Request;
 
 class Image
 {
@@ -92,14 +93,12 @@ class Image
         /**
          * @var Client $client
          */
-        $client = $this->clientFactory->create(['config' => [
-            'base_uri' => $value
-        ]]);
-        $response = '';
+        $client = $this->clientFactory->create();
 
         try {
-            $response = $client->request('GET')->getBody();
+            $response = $client->request(Request::HTTP_METHOD_GET, $value)->getBody();
         } catch (GuzzleException $e) {
+            $response = '';
             $this->log->logError($e->getMessage());
         }
 
@@ -114,12 +113,17 @@ class Image
      */
     public function getFileName($url)
     {
-        // phpcs:ignore Magento2.Functions.DiscouragedFunction
-        $imageName = basename((string) $url);
-        // Remove any URL entities
-        $imageName = urldecode($imageName);
-        // Replace spaces with -
-        $imageName = preg_replace('/\s+/', '-', $imageName);
+        if (preg_match('/http:\/\/placehold\.it\/(.*)\/jpg$/', $url, $match)) {
+            $imageName = sprintf('%s.jpg', $match[1]);
+        } else {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $imageName = basename((string) $url);
+            // Remove any URL entities
+            $imageName = urldecode($imageName);
+            // Replace spaces with -
+            $imageName = preg_replace('/\s+/', '-', $imageName);
+        }
+
         return $imageName;
     }
 

--- a/Component/TaxRates.php
+++ b/Component/TaxRates.php
@@ -2,13 +2,13 @@
 
 namespace CtiDigital\Configurator\Component;
 
-use CtiDigital\Configurator\Api\FileComponentInterface;
+use CtiDigital\Configurator\Api\ComponentInterface;
 use CtiDigital\Configurator\Api\LoggerInterface;
 use CtiDigital\Configurator\Exception\ComponentException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\TaxImportExport\Model\Rate\CsvImportHandler;
 
-class TaxRates implements FileComponentInterface
+class TaxRates implements ComponentInterface
 {
     protected $alias = 'taxrates';
     protected $name = 'Tax Rates';
@@ -44,18 +44,84 @@ class TaxRates implements FileComponentInterface
     public function execute($data = null)
     {
         try {
-            $filePath =  BP . '/' . $data;
-            $this->log->logInfo(
-                sprintf('"%s" is being imported', $filePath)
-            );
+            // Sort data into the column order importExport requires
+            $sortedData = $this->getSortedData($data);
 
-            $this->csvImportHandler->importFromCsvFile(['tmp_name' => $filePath]);
-            $this->log->logInfo(
-                sprintf('"%s" Tax Rules import finished', $filePath)
-            );
+            // Generate sorted csv file
+            $tmpFile = $this->getTmpFile($sortedData);
+
+            // Pass the temporary file name to the import handler
+            $this->csvImportHandler->importFromCsvFile(['tmp_name' => $tmpFile]);
+
+            // Remove the temporary file
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            unlink($tmpFile);
+
+            // We don't know how many were successfully imported so we can't log the
+            // number of records imported, but we can log that the import was successful.
+            $this->log->logInfo('Tax rates finished importing, check the rates in the admin panel.');
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
         }
+    }
+
+    /**
+     * Reorder each row into the fixed column order Magento's CsvImportHandler expects.
+     *
+     * @param array $data
+     * @return array
+     */
+    protected function getSortedData(array $data): array
+    {
+        $sortedData = [];
+
+        foreach ($data as $index => $rate) {
+            if ($index === 0) {
+                $sortedData[] = $rate;
+                continue; // Skip the header row
+            }
+
+            $relativeData = array_combine($data[0], $rate);
+
+            // Reorder the data to match the format the importer requires
+            $rateData = [
+                $relativeData['code'],
+                $relativeData['tax_country_id'],
+                $relativeData['tax_region_id'],
+                $relativeData['tax_postcode'],
+                $relativeData['rate'],
+                $relativeData['zip_is_range'],
+                $relativeData['zip_from'],
+                $relativeData['zip_to']
+            ];
+            $sortedData[] = $rateData;
+        }
+        return $sortedData;
+    }
+
+    /**
+     * Write the sorted data to a temporary CSV file and return its path.
+     *
+     * @param array $sortedData
+     * @return string
+     */
+    protected function getTmpFile(array $sortedData): string
+    {
+        // Define a temporary file name
+        $tmpFile = sys_get_temp_dir() . '/tax_rates_' . uniqid() . '.csv';
+
+        // Write the CSV data to the temporary file
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        $fileHandle = fopen($tmpFile, 'w');
+        foreach ($sortedData as $line) {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            fputcsv($fileHandle, $line, escape: '');
+        }
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        fclose($fileHandle);
+
+        // Return the path to the temporary file
+        return $tmpFile;
     }
 
     /**

--- a/Model/Logging.php
+++ b/Model/Logging.php
@@ -35,6 +35,9 @@ class Logging implements LoggerInterface
         for ($i = 0; $i < $nest; $i++) {
             $prepend .= "| ";
         }
+        if (is_array($message)) {
+            $message = 'Log array: ' . print_r($message, 1);
+        }
         $this->output->writeln($prepend . '<' . $level . '>' . $message . '</' . $level . '>');
     }
 

--- a/Model/Logging.php
+++ b/Model/Logging.php
@@ -60,6 +60,8 @@ class Logging implements LoggerInterface
 
     public function logInfo($message, $nest = 0)
     {
-        $this->log($message, $this::LEVEL_INFO, $nest);
+        if ($this->level > OutputInterface::VERBOSITY_QUIET) {
+            $this->log($message, $this::LEVEL_INFO, $nest);
+        }
     }
 }

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -222,6 +222,7 @@ class Processor
 
             // Loop through components and run them individually in the master.yaml order
             foreach ($master as $componentAlias => $componentConfig) {
+                if ($componentConfig['enabled'] === 0) continue;
                 // Run the component in question
                 $areaCode = ($componentAlias === 'pages') ? Area::AREA_FRONTEND : Area::AREA_ADMINHTML;
                 $this->state->emulateAreaCode(

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -222,7 +222,9 @@ class Processor
 
             // Loop through components and run them individually in the master.yaml order
             foreach ($master as $componentAlias => $componentConfig) {
-                if ($componentConfig['enabled'] === 0) continue;
+                if ($componentConfig['enabled'] === 0) {
+                    continue;
+                }
                 // Run the component in question
                 $areaCode = ($componentAlias === 'pages') ? Area::AREA_FRONTEND : Area::AREA_ADMINHTML;
                 $this->state->emulateAreaCode(

--- a/Samples/Components/Attributes/attributes.yaml
+++ b/Samples/Components/Attributes/attributes.yaml
@@ -34,3 +34,82 @@ attributes:
     product_types:
       - bundle
       - simple
+  book_format:
+    global: 1
+    label: Book Format
+    type: int
+    input: select
+    visible_on_front: 1
+    filterable: 1
+    filterable_in_search: 1
+    required: 0
+    searchable: 1
+    visible_in_advanced_search: 1
+    used_for_promo_rules: 0
+    used_in_product_listing: 1
+    position: 10
+    product_types:
+      - simple
+      - configurable
+    option:
+      values:
+        - "Hardback"
+        - "Paperback"
+  colour_with_swatches:
+    global: 1
+    label: Colour
+    type: int
+    input: swatch_visual
+    visible_on_front: 1
+    filterable: 1
+    filterable_in_search: 1
+    required: 0
+    searchable: 1
+    visible_in_advanced_search: 1
+    used_for_promo_rules: 0
+    used_in_product_listing: 1
+    position: 20
+    product_types:
+      - simple
+      - configurable
+    option:
+      values:
+        'Aqua blue': '#A1DAD7'
+        'Aqua marine': '#7FFFD4'
+        'Black': '#000000'
+        'Blue': '#0000FF'
+        'Bottle green': '#093624'
+        'Bright blue': '#2EFFFA'
+        'Brown': '#964B00'
+        'Cerise pink': '#DA3287'
+        'Cinnabar': '#E34234'
+        'Dark brown': '#5F1811'
+        'Dark green': '#105B10'
+        'Dark grey': '#484747'
+        'Dark purple': '#3A0156'
+        'Denim blue': '#1560BD'
+        'Forest green': '#228B22'
+        'French navy': '#005280'
+        'Grape': '#381A51'
+        'Green': '#00FF00'
+        'Grey': '#808080'
+        'Indigo denim': '#3752B3'
+        'Khaki': '#F0E68C'
+        'Lemon yellow': '#FDE910'
+        'Light blue': '#D6E6FF'
+        'Light green': '#D6FFD8'
+        'Light grey': '#DEDEDE'
+        'Lime green': '#BFFF00'
+        'Mustard yellow': '#FFDB58'
+        'Navy blue': '#000080'
+        'Orange': '#FF681F'
+        'Pale Green': '#72836E'
+        'Pink': '#FFC0CB'
+        'Purple': '#660099'
+        'Red': '#FF0000'
+        'Sky blue': '#76D7EA'
+        'Slate grey': '#708090'
+        'Tomato red': '#FF3100'
+        'Turquoise': '#30D5C8'
+        'White': '#FFFFFF'
+        'Yellow': '#FFFF00'

--- a/Samples/Components/OrderStatuses/orderstatuses.yaml
+++ b/Samples/Components/OrderStatuses/orderstatuses.yaml
@@ -1,0 +1,11 @@
+order_statuses:
+  - state: processing
+    statuses:
+      - code: processing_custom1
+        name: Processing Custom 1
+      - code: processing_custom2
+        name: Processing Custom 2
+  - state: new
+    statuses:
+      - code: new_custom1
+        name: New Custom 1

--- a/Samples/Components/TaxRates/multi_example_taxrates.csv
+++ b/Samples/Components/TaxRates/multi_example_taxrates.csv
@@ -1,6 +1,6 @@
-Code,Country,State,Zip/Post Code,Rate,Zip/Post is Range,Range From,Range To,default
-VAT Standard Rate,GB,*,*,20,,,,
-VAT Zero Rate,GB,*,*,0,,,,
-Czech Republic,CZ,*,*,20,,,,
-Austria,AT,*,*,20,,,,
-Belgium,BE,*,*,20,,,,
+code,tax_country_id,tax_region_id,rate,tax_postcode,zip_is_range,zip_from,zip_to
+"VAT Standard Rate","GB","*","20","*","","",""
+"VAT Zero Rate","GB","*","0","*","","",""
+"Czech Republic","CZ","*","20","*","","",""
+"Austria","AT","*","20","*","","",""
+"Belgium","BE","*","20","*","","",""

--- a/Samples/Components/TaxRates/taxrates.csv
+++ b/Samples/Components/TaxRates/taxrates.csv
@@ -1,3 +1,3 @@
-"Code","Country","State","Zip/Post Code","Rate","Zip/Post is Range","Range From","Range To","default"
-"US-CA-*-Rate 1","US","CA","*","8.2500","","","",""
-"US-NY-*-Rate 1","US","NY","*","8.3750","","","",""
+code,tax_country_id,tax_region_id,rate,tax_postcode,zip_is_range,zip_from,zip_to
+"US-CA-*-Rate 1","US","CA","8.2500","*","","",""
+"US-NY-*-Rate 1","US","NY","8.3750","*","","",""

--- a/Samples/master.yaml
+++ b/Samples/master.yaml
@@ -178,3 +178,8 @@ shippingtablerates:
   method: code
   sources:
     - ../configurator/ShippingTableRates/shippingtablerates.yaml
+order_statuses:
+  enabled: 1
+  method: code
+  sources:
+    - ../configurator/OrderStatuses/orderstatuses.yaml

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -53,6 +53,7 @@
                 <item name="shippingtablerates" xsi:type="object">CtiDigital\Configurator\Component\ShippingTableRates</item>
                 <item name="customer_attributes" xsi:type="object">CtiDigital\Configurator\Component\CustomerAttributes</item>
                 <item name="tiered_prices" xsi:type="object">CtiDigital\Configurator\Component\TieredPrices</item>
+                <item name="order_statuses" xsi:type="object">CtiDigital\Configurator\Component\OrderStatuses</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
## Summary

Backports useful changes from upstream `ctidigital/magento2-configurator:develop` that our fork was missing. Each item was adapted to our fork's architecture (`ComponentInterface` with `execute`/`getAlias`/`getDescription`, di.xml component registration, multi-master) rather than applied verbatim.

## What's included

| Feature | Notes |
|---|---|
| **Zend → Guzzle image migration** | `Component/Product/Image.php` no longer uses the deprecated/removed `Magento\Framework\HTTP\ZendClient`. Fixes image imports on modern Magento. |
| **OrderStatuses component** | New `Component/OrderStatuses.php` + sample. Rewritten to `implements ComponentInterface` and registered in `etc/di.xml` (upstream used `etc/configurator.xml`, which our fork doesn't have). |
| **Customer-group fixes (CES-984)** | Adds `validateGroupName()` (name mandatory + 32-char limit) and a Processor guard for disabled components. |
| **Don't log info when quiet** | `logInfo()` now respects `-q`; logging also handles array messages. |
| **Attribute swatches** | Merged into our reworked `Attributes.php`; `$optionCollection` declared as a real property (upstream used an undeclared dynamic property, deprecated in PHP 8.2+). |
| **Tax rates: CSV column reordering** | `TaxRates` now `implements ComponentInterface` so the Processor parses the CSV; `getSortedData()` reorders each row into the positional order Magento's `CsvImportHandler` requires. Verified against Magento source (import is positional). |

## Deliberately skipped

- **CMS-block-to-category (`d22b83c`)** — already implemented in our fork, and better (we load the block by unique `identifier` via `landing_page`; upstream loaded by non-unique `title`).
- **`TaxRules` refactor & `da619d3`** — almost entirely PHP 8.4 syntax (typed constants, promoted `readonly` ctors) / a Categories constructor refactor on upstream's divergent structure. Belongs with the separate **PHP 8.4 compatibility** effort, not this PR.

## Notes / follow-ups

- Sample tax-rate CSVs were rewritten with machine-name headers (required for the name-based reorder) and correctly aligned data — upstream's updated samples scrambled the header without moving the values (rate/postcode swaps).
- A couple of small follow-up commits enforce Magento coding standards (braces) and declared-property conventions.
- **Not runtime-tested against a live Magento** (no vendor install in this repo). The tax-rate import and swatch conversion in particular should be verified on a real store before merge.
- **PHP 8.4 compatibility** (upstream `8b128eb`) is intentionally left for a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
