### PR TITLE
v2: store-scope fixes, media gallery registration, enabled-flag hardening

### DIFF
--- a/Component/Media.php
+++ b/Component/Media.php
@@ -16,6 +16,9 @@ use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\MediaGalleryApi\Api\GetAssetsByPathsInterface;
+use Magento\MediaGalleryApi\Api\SaveAssetsInterface;
+use Magento\MediaGallerySynchronizationApi\Model\CreateAssetFromFileInterface;
 
 class Media implements ComponentInterface
 {
@@ -26,7 +29,10 @@ class Media implements ComponentInterface
 
     public function __construct(
         private readonly DirectoryList $directoryList,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly CreateAssetFromFileInterface $createAssetFromFile,
+        private readonly SaveAssetsInterface $saveAssets,
+        private readonly GetAssetsByPathsInterface $getAssetsByPaths
     ) {
     }
 
@@ -160,7 +166,42 @@ class Media implements ComponentInterface
         // phpcs:ignore Magento2.Functions.DiscouragedFunction
         file_put_contents($path, $fileContents);
         $this->log->logInfo(sprintf('Created new file: %s', $path), $nest);
+        $this->registerMediaGalleryAsset($path, $nest);
         $result->recordCreated();
+    }
+
+    /**
+     * Register WYSIWYG media in the media gallery so it shows in the admin gallery UI.
+     *
+     * Only wysiwyg assets are registered (matching how the admin gallery indexes them).
+     * Failures are logged but never abort the run.
+     */
+    private function registerMediaGalleryAsset(string $path, int $nest): void
+    {
+        if (!str_contains($path, DIRECTORY_SEPARATOR . 'wysiwyg' . DIRECTORY_SEPARATOR)) {
+            return;
+        }
+
+        try {
+            $mediaPath = $this->directoryList->getPath(DirectoryList::MEDIA);
+            $relativePath = str_replace($mediaPath . DIRECTORY_SEPARATOR, '', $path);
+            $relativePath = str_replace('\\', '/', $relativePath);
+            $normalizedPath = '/' . $relativePath;
+
+            // Skip if the asset is already registered.
+            if ($this->getAssetsByPaths->execute([$normalizedPath]) !== []) {
+                return;
+            }
+
+            $asset = $this->createAssetFromFile->execute($relativePath);
+            $this->saveAssets->execute([$asset]);
+            $this->log->logInfo(sprintf('Registered media asset: %s', $relativePath), $nest);
+        } catch (\Exception $e) {
+            $this->log->logError(
+                sprintf('Failed to register media asset %s: %s', $path, $e->getMessage()),
+                $nest
+            );
+        }
     }
 
     public function getAlias(): string

--- a/Component/Pages.php
+++ b/Component/Pages.php
@@ -26,9 +26,12 @@ use Magento\Framework\Escaper;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\UrlInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\Store;
 use Symfony\Component\Filesystem\Filesystem;
+use Magento\Framework\App\Area;
 use Magento\Framework\EntityManager\MetadataPool;
 
 /**
@@ -55,6 +58,7 @@ class Pages implements ComponentInterface
         private readonly ObjectManagerInterface $objectManager,
         private readonly ResourceConnection $resourceConnection,
         private readonly MetadataPool $metadataPool,
+        private readonly Emulation $emulation,
     ) {
         if (class_exists('Hyva\Theme\Model\ViewModelRegistry')) {
             $this->viewModelRegistry = $this->objectManager->create('Hyva\Theme\Model\ViewModelRegistry');
@@ -148,61 +152,86 @@ class Pages implements ComponentInterface
                 $this->checkRequiredFields($pageData);
                 $this->setDefaultFields($pageData);
 
-                // Loop through each attribute of the data array
-                foreach ($pageData as $key => $value) {
-                    // Check if content is from a file source
-                    if ($key == "source") {
-                        $key = 'content';
+                // Render store-scoped content (blocks, view models, config) under the target
+                // store so the saved content reflects that store rather than the admin default.
+                $emulationStarted = false;
+                if (!empty($pageData['stores']) && is_array($pageData['stores'])) {
+                    $firstStore = $this->storeRepository->get((string) reset($pageData['stores']));
+                    $this->emulation->startEnvironmentEmulation(
+                        (int) $firstStore->getId(),
+                        Area::AREA_FRONTEND,
+                        true
+                    );
+                    $emulationStarted = true;
+                }
 
-                        $file = BP . '/' . $value;
+                try {
+                    // Loop through each attribute of the data array
+                    foreach ($pageData as $key => $value) {
+                        // Check if content is from a file source
+                        if ($key == "source") {
+                            $key = 'content';
 
-                        if (!$this->filesystem->exists($file)) {
-                            return;
+                            $file = BP . '/' . $value;
+
+                            if (!$this->filesystem->exists($file)) {
+                                return;
+                            }
+
+                            // phpcs:disable
+                            ob_start();
+
+                            $dictionary = [
+                                'escaper' => $this->escaper,
+                                'viewModels' => $this->viewModelRegistry
+                            ];
+
+                            try {
+                                extract($dictionary, EXTR_SKIP);
+                                include $file;
+                            } catch (Exception $exception) {
+                                ob_end_clean();
+                                throw $exception;
+                            }
+
+                            $value = ob_get_clean();
+                            // phpcs:enable
                         }
 
-                        // phpcs:disable
-                        ob_start();
-
-                        $dictionary = [
-                            'escaper' => $this->escaper,
-                            'viewModels' => $this->viewModelRegistry
-                        ];
-
-                        try {
-                            extract($dictionary, EXTR_SKIP);
-                            include $file;
-                        } catch (Exception $exception) {
-                            ob_end_clean();
-                            throw $exception;
+                        // Skip stores
+                        if ($key == "stores") {
+                            continue;
                         }
 
-                        $value = ob_get_clean();
-                        // phpcs:enable
-                    }
-
-                    // Skip stores
-                    if ($key == "stores") {
-                        continue;
-                    }
-
-                    // Log the old value if any
-                    $this->log->logComment(sprintf(
-                        "Checking page %s, key %s => %s",
-                        $identifier . ' (' . $page->getId() . ')',
-                        $key,
-                        $page->getData($key)
-                    ), 1);
-
-                    // Check if there is a difference in value
-                    if ($page->getData($key) != $value) {
-                        $page->setData($key, $value);
-
-                        $this->log->logInfo(sprintf(
-                            "Set page %s, key %s => %s",
+                        // Log the old value if any
+                        $this->log->logComment(sprintf(
+                            "Checking page %s, key %s => %s",
                             $identifier . ' (' . $page->getId() . ')',
                             $key,
-                            $value
+                            $page->getData($key)
                         ), 1);
+
+                        // Check if there is a difference in value
+                        if ($page->getData($key) != $value) {
+                            $page->setData($key, $value);
+
+                            $this->log->logInfo(sprintf(
+                                "Set page %s, key %s => %s",
+                                $identifier . ' (' . $page->getId() . ')',
+                                $key,
+                                $value
+                            ), 1);
+                        }
+                    }
+                } finally {
+                    if ($emulationStarted) {
+                        $this->emulation->stopEnvironmentEmulation();
+
+                        // Reset the URL builder to clear base URLs cached during emulation.
+                        $urlBuilder = $this->objectManager->get(UrlInterface::class);
+                        if (method_exists($urlBuilder, '_resetState')) {
+                            $urlBuilder->_resetState();
+                        }
                     }
                 }
 

--- a/Component/Widgets.php
+++ b/Component/Widgets.php
@@ -72,6 +72,11 @@ class Widgets implements ComponentInterface
     public function processWidget(array $widgetData, bool $dryRun, ComponentResult $result): void
     {
         try {
+            // Capture the configured stores so block references resolve in the right scope.
+            $stores = (isset($widgetData['stores']) && is_array($widgetData['stores']))
+                ? $widgetData['stores']
+                : null;
+
             $widget = $this->findWidgetByInstanceTypeAndTitle($widgetData['instance_type'], $widgetData['title']);
 
             $isNew = false;
@@ -95,7 +100,7 @@ class Widgets implements ComponentInterface
 
                 if ($key == "parameters") {
                     $key = "widget_parameters";
-                    $value = $this->populateWidgetParameters($value);
+                    $value = $this->populateWidgetParameters($value, $stores);
                 }
 
                 if ($key == "theme") {
@@ -226,12 +231,13 @@ class Widgets implements ComponentInterface
 
     /**
      * @param array $parameters
+     * @param array|null $stores Store codes the widget is assigned to, used to scope block lookups.
      * @todo better support with parameters that reference IDs of objects
      */
-    public function populateWidgetParameters(array $parameters): string
+    public function populateWidgetParameters(array $parameters, ?array $stores = null): string
     {
         // Process block_identifier if present
-        $processedParameters = $this->processBlockIdentifiers($parameters);
+        $processedParameters = $this->processBlockIdentifiers($parameters, $stores);
 
         // Default property return
         return $this->serializer->serialize($processedParameters);
@@ -247,15 +253,22 @@ class Widgets implements ComponentInterface
      * -    block_identifier: <block_identifier> # e.g. venta-contact-us-faq
      * ```
      * @param array $parameters
+     * @param array|null $stores Store codes used to scope the block lookup.
      */
-    private function processBlockIdentifiers(array $parameters): array
+    private function processBlockIdentifiers(array $parameters, ?array $stores = null): array
     {
         $processedParameters = $parameters;
+
+        // Convert store codes to IDs once so block lookups can be scoped.
+        $storeIds = null;
+        if ($stores) {
+            $storeIds = explode(',', $this->getCommaSeparatedStoreIds($stores));
+        }
 
         foreach ($parameters as $key => $value) {
             if ($key === 'block_identifier' && is_string($value)) {
                 try {
-                    $blockId = $this->getBlockIdByIdentifier($value);
+                    $blockId = $this->getBlockIdByIdentifier($value, $storeIds);
                     // Replace block_identifier with block_id for the widget
                     unset($processedParameters['block_identifier']);
                     $processedParameters['block_id'] = $blockId;
@@ -280,14 +293,26 @@ class Widgets implements ComponentInterface
      * Get CMS block ID by identifier
      *
      * @param string $identifier
+     * @param array|null $storeIds Store IDs to scope the lookup; the first is used when provided.
      * @throws ComponentException
      */
-    private function getBlockIdByIdentifier($identifier): string
+    private function getBlockIdByIdentifier($identifier, ?array $storeIds = null): string
     {
         try {
-            $searchCriteria = $this->criteriaBuilder
-                ->addFilter('identifier', $identifier)
-                ->create();
+            $this->criteriaBuilder->addFilter('identifier', $identifier);
+
+            // Scope the lookup to the widget's store so the correct block is matched
+            // when the same identifier exists in multiple stores.
+            if (!empty($storeIds)) {
+                $firstStoreId = reset($storeIds);
+                $this->criteriaBuilder->addFilter('store_id', $firstStoreId, 'in');
+                $this->log->logInfo(
+                    sprintf('Looking for block "%s" in store ID: %s', $identifier, $firstStoreId),
+                    1
+                );
+            }
+
+            $searchCriteria = $this->criteriaBuilder->create();
 
             $blocks = $this->blockRepository->getList($searchCriteria);
 

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -272,7 +272,10 @@ class Processor
 
             // Loop through components and run them individually in the master.yaml order
             foreach ($master as $componentAlias => $componentConfig) {
-                if ($componentConfig['enabled'] === 0) {
+                if (isset($componentConfig['enabled']) && !$componentConfig['enabled']) {
+                    $this->log->logComment(
+                        sprintf("Skipping component '%s' as it is disabled (enabled: 0)", $componentAlias)
+                    );
                     continue;
                 }
                 // Run the component in question


### PR DESCRIPTION
Batch A from the team feedback thread — ports four production-proven patches from `belomax-venta` into Configurator v2. All four are self-contained and low-risk.

## Changes

| Source patch | File | What it does |
|---|---|---|
| BXH-152 | `Component/Pages.php` | Emulate the target store (frontend area) while rendering page `source` content, so store-scoped blocks / view-models / config resolve under the right store instead of the admin default. Cleanup via `try/finally` + URL-builder `_resetState()`. |
| BXH-129 | `Component/Widgets.php` | Thread the widget's `stores` through `populateWidgetParameters` → `processBlockIdentifiers` → `getBlockIdByIdentifier`, scoping `block_identifier` → `block_id` resolution to the widget's store so same-identifier blocks across stores match correctly. |
| BXH-133 | `Component/Media.php` | Register downloaded `/wysiwyg/` files in the media gallery (`media_gallery_asset`) so they appear in the admin gallery UI. Idempotent via `getAssetsByPaths`; failures are logged, never fatal. |
| BXH-133 | `Model/Processor.php` | `enabled` check now treats any falsy value (`false`, `"0"`, `0`) as disabled, not just the int `0`. Explicit `--component` runs still override the flag. |

## Verification

- `php -l` clean on all four files.
- `setup:di:compile` **succeeds** on Magento 2.4.7-p3 / PHP 8.3 — confirms the new constructor dependencies all resolve (`Emulation`, `UrlInterface`, and the three `MediaGallery*` interfaces, which have core `preference` entries).

## Notes / known limitations (carried over from the original patches)

- Both store fixes use the **first** store in the `stores` list. Genuinely per-store page content / block resolution would be a larger change.
- Media registration is scoped to `/wysiwyg/` assets only, matching the proven Belomax behavior.
- Optional follow-up: add `<sequence>` entries for the MediaGallery modules in `etc/module.xml` for explicit load order (DI compiled fine without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)