### PR TITLE
v2 Batch B: unify create/maintain mode + versioning across all components

### DIFF
--- a/Api/ReconciliationOutcome.php
+++ b/Api/ReconciliationOutcome.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright (c) 2016 CTI Digital
+ * Copyright (c) 2026 Magebit, Ltd.
+ *
+ * Licensed under the MIT License; see the LICENSE file in the project root.
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\Configurator\Api;
+
+use Magebit\Configurator\Model\ComponentResult;
+
+/**
+ * What a component should do with a single entity once the ReconciliationGate
+ * has weighed its mode, version and changed/unchanged state.
+ */
+enum ReconciliationOutcome: string
+{
+    /** Entity does not exist yet — create it. */
+    case Create = 'create';
+
+    /** Entity exists and should be updated to match the config. */
+    case Update = 'update';
+
+    /** Leave the existing entity untouched. */
+    case Skip = 'skip';
+
+    public function isSkip(): bool
+    {
+        return $this === self::Skip;
+    }
+
+    /**
+     * Record this outcome against a component result, so call sites don't
+     * each re-implement the create/update/skip mapping.
+     */
+    public function record(ComponentResult $result, int $count = 1): void
+    {
+        match ($this) {
+            self::Create => $result->recordCreated($count),
+            self::Update => $result->recordUpdated($count),
+            self::Skip => $result->recordSkipped($count),
+        };
+    }
+}

--- a/Component/AdminRoles.php
+++ b/Component/AdminRoles.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Authorization\Model\Acl\Role\Group as RoleGroup;
 use Magento\Authorization\Model\ResourceModel\Role as RoleResource;
 use Magento\Authorization\Model\RoleFactory;
@@ -35,7 +38,8 @@ class AdminRoles implements ComponentInterface
         private readonly RoleFactory $roleFactory,
         private readonly RoleResource $roleResource,
         private readonly RulesFactory $rulesFactory,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -54,7 +58,14 @@ class AdminRoles implements ComponentInterface
                 if (!isset($role['name'])) {
                     throw new ComponentException((string) __('An adminroles entry is missing the "name" key.'));
                 }
-                $this->createAdminRole($role['name'], $role['resources'] ?? null, $context->isDryRun(), $result);
+                $this->createAdminRole(
+                    $role['name'],
+                    $role['resources'] ?? null,
+                    $context->getMode(),
+                    $role['version'] ?? null,
+                    $context->isDryRun(),
+                    $result
+                );
             } catch (ComponentException $e) {
                 $this->log->logError($e->getMessage());
                 $result->addError($e->getMessage());
@@ -73,21 +84,36 @@ class AdminRoles implements ComponentInterface
     private function createAdminRole(
         string $roleName,
         ?array $resources,
+        ComponentMode $mode,
+        ?string $version,
         bool $dryRun,
         ComponentResult $result
     ): void {
         $role = $this->roleFactory->create();
         $existing = $role->getCollection()->addFieldToFilter('role_name', $roleName)->getFirstItem();
+        $exists = (bool) $existing->getId();
 
-        if ($existing->getId()) {
-            $this->log->logInfo(sprintf('Admin Role "%s" already exists, creation skipped', $roleName));
+        $request = new ReconciliationRequest(self::ALIAS, $roleName, $mode, $exists, $version ? (int) $version : null);
+
+        if ($this->gate->decide($request)->isSkip()) {
+            // In create mode an existing role (and its resources) is left untouched.
+            $this->log->logInfo(sprintf('Admin Role "%s" exists, skipped (create mode)', $roleName));
             $result->recordSkipped();
+            return;
+        }
+
+        // Existing role in maintain mode (or a version bump): reconcile its resources.
+        if ($exists) {
             $this->setResourceIds($existing, $resources, $dryRun);
+            $this->gate->commitVersion($request, $dryRun);
+            $result->recordUpdated();
             return;
         }
 
         if ($dryRun) {
             $this->log->logInfo(sprintf('[dry-run] Would create Admin Role "%s"', $roleName));
+            $this->setResourceIds($existing, $resources, $dryRun);
+            $this->gate->commitVersion($request, $dryRun);
             $result->recordCreated();
             return;
         }
@@ -101,8 +127,9 @@ class AdminRoles implements ComponentInterface
             ->setSortOrder(0);
         $this->roleResource->save($role);
 
-        $result->recordCreated();
         $this->setResourceIds($role, $resources, $dryRun);
+        $this->gate->commitVersion($request, $dryRun);
+        $result->recordCreated();
     }
 
     /**

--- a/Component/AdminUsers.php
+++ b/Component/AdminUsers.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Authorization\Model\RoleFactory;
 use Magento\Framework\Validator\Exception as ValidatorException;
 use Magento\User\Model\ResourceModel\User as UserResource;
@@ -36,7 +40,8 @@ class AdminUsers implements ComponentInterface
         private readonly UserFactory $userFactory,
         private readonly UserResource $userResource,
         private readonly RoleFactory $roleFactory,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -67,7 +72,7 @@ class AdminUsers implements ComponentInterface
                 }
 
                 try {
-                    $this->createAdminUser($userData, $roleId, $context->isDryRun(), $result);
+                    $this->createAdminUser($userData, $roleId, $context->getMode(), $context->isDryRun(), $result);
                 } catch (ValidatorException $e) {
                     $message = sprintf('Magento Framework Validation Exception: %s', $e->getMessage());
                     $this->log->logError($message);
@@ -87,16 +92,32 @@ class AdminUsers implements ComponentInterface
      *
      * @param array $userData
      */
-    private function createAdminUser(array $userData, int $roleId, bool $dryRun, ComponentResult $result): void
-    {
+    private function createAdminUser(
+        array $userData,
+        int $roleId,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
         $fullName = $userData['firstname'] . ' ' . $userData['secondname'];
 
         $user = $this->userFactory->create();
-        $exists = $user->getCollection()->addFieldToFilter('email', $userData['email'])->getSize() > 0;
+        $existing = $user->getCollection()->addFieldToFilter('email', $userData['email'])->getFirstItem();
+        $exists = (bool) $existing->getId();
 
-        if ($exists) {
+        $version = $userData['version'] ?? null;
+        $request = new ReconciliationRequest(
+            self::ALIAS,
+            (string) $userData['email'],
+            $mode,
+            $exists,
+            $version ? (int) $version : null
+        );
+
+        $outcome = $this->gate->decide($request);
+        if ($outcome->isSkip()) {
             $this->log->logComment(sprintf(
-                'Admin User "%s" creation skipped: a user with the email "%s" already exists',
+                'Admin User "%s" (%s) skipped (create mode)',
                 $fullName,
                 $userData['email']
             ));
@@ -105,36 +126,50 @@ class AdminUsers implements ComponentInterface
         }
 
         if ($dryRun) {
-            $this->log->logInfo(sprintf('[dry-run] Would create Admin User "%s" (%s)', $fullName, $userData['email']));
-            $result->recordCreated();
+            $this->log->logInfo(sprintf(
+                '[dry-run] Would %s Admin User "%s" (%s)',
+                $outcome->value,
+                $fullName,
+                $userData['email']
+            ));
+            $outcome->record($result);
             return;
         }
 
-        $this->log->logInfo(sprintf('Admin User "%s" (%s) being created', $fullName, $userData['email']));
+        $isCreate = $outcome === ReconciliationOutcome::Create;
+        $user = $isCreate ? $user : $this->userFactory->create()->load($existing->getId());
+
+        $this->log->logInfo(sprintf('Admin User "%s" (%s) being %s', $fullName, $userData['email'], $outcome->value));
 
         $user
             ->setUserName($userData['username'])
             ->setFirstName($userData['firstname'])
             ->setLastName($userData['secondname'])
             ->setEmail($userData['email'])
-            ->setPassword($userData['password'])
             ->setIsActive(true)
             ->setRoleId($roleId);
+
+        // Only set the password on creation; re-setting it on every maintain run
+        // would re-hash and force the user to reset their password.
+        if ($isCreate) {
+            $user->setPassword($userData['password']);
+        }
 
         if (array_key_exists('interface_locale', $userData)) {
             $user->setInterfaceLocale($userData['interface_locale']);
         }
 
         if ($user->validate() !== true) {
-            $message = sprintf('Admin User "%s" failed validation and was not created', $fullName);
+            $message = sprintf('Admin User "%s" failed validation and was not saved', $fullName);
             $this->log->logError($message);
             $result->addError($message);
             return;
         }
 
         $this->userResource->save($user);
-        $result->recordCreated();
-        $this->log->logInfo(sprintf('Admin User "%s" created successfully', $fullName));
+        $this->gate->commitVersion($request, $dryRun);
+        $outcome->record($result);
+        $this->log->logInfo(sprintf('Admin User "%s" %s successfully', $fullName, $outcome->value));
     }
 
     /**

--- a/Component/ApiIntegrations.php
+++ b/Component/ApiIntegrations.php
@@ -11,15 +11,19 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magento\Integration\Model\IntegrationFactory;
 use Magento\Integration\Model\Oauth\TokenFactory;
 use Magento\Integration\Model\ResourceModel\Oauth\Token as TokenResource;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
 use Magento\Integration\Model\AuthorizationService;
 use Magento\Integration\Api\IntegrationServiceInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 
 /**
  * @SuppressWarnings(PHPMD.ShortVariable)
@@ -35,7 +39,8 @@ class ApiIntegrations implements ComponentInterface
         private readonly AuthorizationService $authorizationService,
         private readonly TokenFactory $tokenFactory,
         private readonly TokenResource $tokenResource,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -56,7 +61,7 @@ class ApiIntegrations implements ComponentInterface
                     continue;
                 }
 
-                $this->createApiIntegration($integrationData, $context->isDryRun(), $result);
+                $this->createApiIntegration($integrationData, $context->getMode(), $context->isDryRun(), $result);
             } catch (ComponentException $e) {
                 $this->log->logError($e->getMessage());
                 $result->addError($e->getMessage());
@@ -66,50 +71,64 @@ class ApiIntegrations implements ComponentInterface
         return $result;
     }
 
-    private function createApiIntegration(array $integrationData, bool $dryRun, ComponentResult $result): void
-    {
+    private function createApiIntegration(
+        array $integrationData,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
         $integration = $this->integrationFactory->create();
-        $integrationCount = $integration->getCollection()
+        $existing = $integration->getCollection()
             ->addFieldToFilter('name', $integrationData['name'])
-            ->getSize();
+            ->getFirstItem();
+        $exists = (bool) $existing->getId();
 
-        if ($integrationCount > 0) {
-            $integration = $integration
-                ->getCollection()
-                ->addFieldToFilter('name', $integrationData['name'])
-                ->getFirstItem();
+        $version = $integrationData['version'] ?? null;
+        $request = new ReconciliationRequest(
+            self::ALIAS,
+            (string) $integrationData['name'],
+            $mode,
+            $exists,
+            $version ? (int) $version : null
+        );
 
+        $outcome = $this->gate->decide($request);
+        if ($outcome->isSkip()) {
             $this->log->logComment(
-                sprintf('API Integration "%s" already exists: Creation skipped', $integration->getName())
+                sprintf('API Integration "%s" exists, skipped (create mode)', $integrationData['name'])
             );
             $result->recordSkipped();
-
             return;
         }
 
         if ($dryRun) {
             $this->log->logInfo(
-                sprintf('[dry-run] Would create API Integration "%s"', $integrationData['name'])
+                sprintf('[dry-run] Would %s API Integration "%s"', $outcome->value, $integrationData['name'])
             );
-            $result->recordCreated();
+            $outcome->record($result);
             return;
         }
 
         $integrationDataArray = $this->convertToUseableData($integrationData);
-        $integration = $this->integrationService->create($integrationDataArray);
-        $integrationId = $integration->getId();
 
-        $this->log->logInfo(
-            sprintf('API Integration "%s" created', $integrationData['name'])
-        );
-        $result->recordCreated();
+        if ($outcome === ReconciliationOutcome::Create) {
+            $integration = $this->integrationService->create($integrationDataArray);
+            $integrationId = $integration->getId();
+            $this->setPermissions($integrationId, $integrationData['resources']);
+            // Token is minted only on creation.
+            $this->activateAndAuthorize($integration->getConsumerId());
+            $this->log->logInfo(sprintf('API Integration "%s" created', $integrationData['name']));
+        } else {
+            // Maintain: update metadata + re-grant permissions, but NEVER re-mint the
+            // access token — doing so would break any live consumer using it.
+            $integrationDataArray['integration_id'] = $existing->getId();
+            $integration = $this->integrationService->update($integrationDataArray);
+            $this->setPermissions($integration->getId(), $integrationData['resources']);
+            $this->log->logInfo(sprintf('API Integration "%s" updated (token preserved)', $integrationData['name']));
+        }
 
-        $this->setPermissions($integrationId, $integrationData['resources']);
-        $this->activateAndAuthorize($integration->getConsumerId());
-
-        $this->log->logInfo(
-            sprintf('API Integration "%s" permissions and authorisation set.', $integrationData['name'])
-        );
+        $this->gate->commitVersion($request, $dryRun);
+        $outcome->record($result);
     }
 
     /**

--- a/Component/AttributeSets.php
+++ b/Component/AttributeSets.php
@@ -76,7 +76,9 @@ class AttributeSets implements ComponentInterface
         ComponentResult $result
     ): void {
         $name = $attributeSetConfig['name'];
-        $existingId = $this->eavSetup->getAttributeSetId(Product::ENTITY, $name);
+        // getAttributeSetId() throws when the set is missing, so probe with getAttributeSet().
+        $attributeSetData = $this->eavSetup->getAttributeSet(Product::ENTITY, $name);
+        $existingId = is_array($attributeSetData) ? ($attributeSetData['attribute_set_id'] ?? null) : null;
         $exists = !empty($existingId);
 
         $version = $attributeSetConfig['version'] ?? null;

--- a/Component/AttributeSets.php
+++ b/Component/AttributeSets.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Eav\Api\AttributeSetRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Eav\Api\Data\AttributeSetInterface;
@@ -31,7 +35,8 @@ class AttributeSets implements ComponentInterface
     public function __construct(
         private readonly EavSetup $eavSetup,
         private readonly AttributeSetRepositoryInterface $attributeSetRepository,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -49,7 +54,12 @@ class AttributeSets implements ComponentInterface
 
         try {
             foreach ($attributeConfigurationData['attribute_sets'] as $attributeSetConfiguration) {
-                $this->processAttributeSet($attributeSetConfiguration, $context->isDryRun(), $result);
+                $this->processAttributeSet(
+                    $attributeSetConfiguration,
+                    $context->getMode(),
+                    $context->isDryRun(),
+                    $result
+                );
             }
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
@@ -59,31 +69,64 @@ class AttributeSets implements ComponentInterface
         return $result;
     }
 
-    protected function processAttributeSet(array $attributeSetConfig, bool $dryRun, ComponentResult $result): void
-    {
-        if ($dryRun) {
-            $this->log->logInfo(
-                sprintf('[dry-run] Would create attribute set: "%s"', $attributeSetConfig['name'])
-            );
-            $result->recordCreated();
+    protected function processAttributeSet(
+        array $attributeSetConfig,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
+        $name = $attributeSetConfig['name'];
+        $existingId = $this->eavSetup->getAttributeSetId(Product::ENTITY, $name);
+        $exists = !empty($existingId);
+
+        $version = $attributeSetConfig['version'] ?? null;
+        $request = new ReconciliationRequest(
+            self::ALIAS,
+            (string) $name,
+            $mode,
+            $exists,
+            $version ? (int) $version : null
+        );
+
+        $outcome = $this->gate->decide($request);
+        if ($outcome->isSkip()) {
+            $this->log->logComment(sprintf('Attribute set "%s" exists, skipped (create mode)', $name));
+            $result->recordSkipped();
             return;
         }
 
-        $this->eavSetup->addAttributeSet(Product::ENTITY, $attributeSetConfig['name']);
+        if ($dryRun) {
+            $this->log->logInfo(sprintf('[dry-run] Would %s attribute set: "%s"', $outcome->value, $name));
+            $outcome->record($result);
+            return;
+        }
 
-        $this->log->logInfo(sprintf('Creating attribute set: "%s"', $attributeSetConfig['name']));
-        $result->recordCreated();
+        $isCreate = $outcome === ReconciliationOutcome::Create;
 
-        $attributeSetId = $this->eavSetup->getAttributeSetId(Product::ENTITY, $attributeSetConfig['name']);
-        $attributeSetEntity = $this->attributeSetRepository->get($attributeSetId);
-        if (array_key_exists('inherit', $attributeSetConfig)) {
+        if ($isCreate) {
+            $this->eavSetup->addAttributeSet(Product::ENTITY, $name);
+            $this->log->logInfo(sprintf('Creating attribute set: "%s"', $name));
+            $existingId = $this->eavSetup->getAttributeSetId(Product::ENTITY, $name);
+        } else {
+            $this->log->logInfo(sprintf('Reconciling attribute set: "%s"', $name));
+        }
+
+        $attributeSetEntity = $this->attributeSetRepository->get($existingId);
+
+        // initFromSkeleton resets the set from a template; only safe on creation,
+        // re-running it on an existing set would wipe its current groups/attributes.
+        if ($isCreate && array_key_exists('inherit', $attributeSetConfig)) {
             $attributeSetEntity->initFromSkeleton($this->getAttributeSetId($attributeSetConfig['inherit']));
             $this->attributeSetRepository->save($attributeSetEntity);
         }
 
+        // Group association is idempotent (it checks existence), so it runs in both modes.
         if (array_key_exists('groups', $attributeSetConfig) && count($attributeSetConfig['groups']) > 0) {
             $this->addAttributeGroups($attributeSetEntity, $attributeSetConfig['groups']);
         }
+
+        $this->gate->commitVersion($request, $dryRun);
+        $outcome->record($result);
     }
 
     protected function addAttributeGroups(AttributeSetInterface $attributeSetEntity, array $attributeGroupData): void

--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Catalog\Model\Product;
 use Magento\Eav\Api\AttributeRepositoryInterface;
 use Magento\Eav\Setup\EavSetup;
@@ -95,7 +98,8 @@ class Attributes implements ComponentInterface
         protected readonly AttributeRepositoryInterface $attributeRepository,
         protected readonly LoggerInterface $log,
         protected readonly AttrOptionCollectionFactory $attrOptionCollectionFactory,
-        protected readonly EavConfig $eavConfig
+        protected readonly EavConfig $eavConfig,
+        protected readonly ReconciliationGate $gate
     ) {
     }
 
@@ -111,7 +115,13 @@ class Attributes implements ComponentInterface
 
         try {
             foreach ($data['attributes'] as $attributeCode => $attributeConfiguration) {
-                $this->processAttribute($attributeCode, $attributeConfiguration, $context->isDryRun(), $result);
+                $this->processAttribute(
+                    $attributeCode,
+                    $attributeConfiguration,
+                    $context->getMode(),
+                    $context->isDryRun(),
+                    $result
+                );
             }
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
@@ -128,6 +138,7 @@ class Attributes implements ComponentInterface
     protected function processAttribute(
         $attributeCode,
         array $attributeConfig,
+        ComponentMode $mode,
         bool $dryRun,
         ComponentResult $result
     ): void {
@@ -148,11 +159,24 @@ class Attributes implements ComponentInterface
             }
         }
 
-        if (!$this->updateAttribute) {
-            $this->log->logComment(sprintf('No update required for attribute %s.', $attributeCode));
+        $version = $attributeConfig['version'] ?? null;
+        $request = new ReconciliationRequest(
+            $this->getAlias(),
+            (string) $attributeCode,
+            $mode,
+            $this->attributeExists,
+            $version ? (int) $version : null,
+            $this->attributeExists ? !$this->updateAttribute : null
+        );
+
+        if ($this->gate->decide($request)->isSkip()) {
+            $this->log->logComment(sprintf('No update for attribute %s (unchanged or create mode).', $attributeCode));
             $result->recordSkipped();
             return;
         }
+
+        // Keep the version marker out of the EAV attribute config.
+        unset($attributeConfig['version']);
 
         if (!array_key_exists('user_defined', $attributeConfig)) {
             $attributeConfig['user_defined'] = 1;
@@ -181,6 +205,7 @@ class Attributes implements ComponentInterface
 
         if ($this->attributeExists) {
             $this->log->logInfo(sprintf('Attribute %s updated.', $attributeCode));
+            $this->gate->commitVersion($request, $dryRun);
             $result->recordUpdated();
             return;
         }
@@ -195,6 +220,7 @@ class Attributes implements ComponentInterface
         //swatch functionality
 
         $this->log->logInfo(sprintf('Attribute %s created.', $attributeCode));
+        $this->gate->commitVersion($request, $dryRun);
         $result->recordCreated();
     }
 

--- a/Component/Blocks.php
+++ b/Component/Blocks.php
@@ -11,13 +11,14 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
-use Magebit\Configurator\Api\VersionManagementInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Api\LoggerInterface;
 use Exception;
-use Magebit\Configurator\Model\Processor;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Cms\Api\Data\BlockInterfaceFactory;
 use Magento\Cms\Model\Block;
@@ -42,7 +43,7 @@ class Blocks implements ComponentInterface
         private readonly LoggerInterface $log,
         private readonly Filesystem $filesystem,
         private readonly Escaper $escaper,
-        private readonly VersionManagementInterface $versionManagement,
+        private readonly ReconciliationGate $gate,
         private readonly ObjectManagerInterface $objectManager
     ) {
         if (class_exists('Hyva\Theme\Model\ViewModelRegistry')) {
@@ -57,7 +58,7 @@ class Blocks implements ComponentInterface
     {
         $result = new ComponentResult();
         $data = $context->getData();
-        $mode = $context->getMode()->value;
+        $mode = $context->getMode();
 
         if (!is_array($data)) {
             $result->addError('No block data found in the source data.');
@@ -79,7 +80,7 @@ class Blocks implements ComponentInterface
     /**
      * @param string $identifier
      * @param array $blockData
-     * @param string $mode
+     * @param ComponentMode $mode
      * @param bool $dryRun
      * @param ComponentResult $result
      * @throws Exception
@@ -88,7 +89,7 @@ class Blocks implements ComponentInterface
     private function processBlock(
         string $identifier,
         array $blockData,
-        string $mode,
+        ComponentMode $mode,
         bool $dryRun,
         ComponentResult $result
     ): void {
@@ -105,17 +106,17 @@ class Blocks implements ComponentInterface
                 $block = null;
 
                 $version = $data['version'] ?? null;
-                $versionId = self::ALIAS . '_' . $identifier;
 
+                // Version key preserves the legacy composition: identifier with the
+                // store codes appended (no separator) when stores are specified.
+                $versionKey = $identifier;
                 if (isset($data['stores'])) {
-                    $versionId .= implode('_', $data['stores']);
+                    $versionKey .= implode('_', $data['stores']);
                 }
 
                 if ($version) {
                     unset($data['version']);
                 }
-
-                $isNewVersion = isset($version) && $this->versionManagement->isNewVersion($versionId, (int) $version);
 
                 // Check if there are existing blocks
                 if ($blocks->count()) {
@@ -133,13 +134,21 @@ class Blocks implements ComponentInterface
                 // Track whether we are creating a new block or updating an existing one
                 $isNew = $block === null;
 
+                $request = new ReconciliationRequest(
+                    self::ALIAS,
+                    $versionKey,
+                    $mode,
+                    !$isNew,
+                    $version ? (int) $version : null
+                );
+
                 // If there is still no block to play with, create a new block object.
                 if ($block === null) {
                     $block = $this->blockFactory->create();
                     $block->setIdentifier($identifier);
                     $canSave = true;
-                } elseif ($mode === Processor::MODE_CREATE && !$isNewVersion) {
-                    // In create mode we skip modifying block
+                } elseif ($this->gate->decide($request)->isSkip()) {
+                    // In create mode we skip modifying an existing block (unless its version bumped).
                     $this->log->logComment(sprintf("'%s' Block exists, skip modifying it (create mode)", $identifier));
                     $result->recordSkipped();
                     continue;
@@ -237,17 +246,7 @@ class Blocks implements ComponentInterface
                     $isNew ? $result->recordCreated() : $result->recordUpdated();
                 }
 
-                if ($version) {
-                    if ($dryRun) {
-                        $this->log->logInfo(sprintf(
-                            "[dry-run] Would set version %d for %s",
-                            (int) $version,
-                            $versionId
-                        ));
-                    } else {
-                        $this->versionManagement->setVersion($versionId, (int) $version);
-                    }
-                }
+                $this->gate->commitVersion($request, $dryRun);
             }
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());

--- a/Component/CatalogPriceRules.php
+++ b/Component/CatalogPriceRules.php
@@ -59,6 +59,7 @@ class CatalogPriceRules implements ComponentInterface
 
         $this->processor->setData($rules)
             ->setConfig($config)
+            ->setMode($context->getMode())
             ->process();
 
         $result->recordCreated($ruleCount);

--- a/Component/CatalogPriceRules/CatalogPriceRulesProcessor.php
+++ b/Component/CatalogPriceRules/CatalogPriceRulesProcessor.php
@@ -8,8 +8,11 @@
 
 namespace Magebit\Configurator\Component\CatalogPriceRules;
 
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\ComponentProcessorInterface;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\CatalogRule\Api\CatalogRuleRepositoryInterface;
 use Magento\CatalogRule\Api\Data\RuleInterfaceFactory;
 use Magento\CatalogRule\Model\Rule;
@@ -51,23 +54,48 @@ class CatalogPriceRulesProcessor implements ComponentProcessorInterface
     private $logger;
 
     /**
+     * @var ReconciliationGate
+     */
+    private $gate;
+
+    /**
+     * @var ComponentMode
+     */
+    private $mode = ComponentMode::Maintain;
+
+    /**
      * CatalogPriceRules constructor.
      *
      * @param LoggerInterface $logger
      * @param RuleInterfaceFactory $ruleFactory
      * @param CatalogRuleRepositoryInterface $catalogRuleRepo
      * @param Job $ruleJob
+     * @param ReconciliationGate $gate
      */
     public function __construct(
         LoggerInterface $logger,
         RuleInterfaceFactory $ruleFactory,
         CatalogRuleRepositoryInterface $catalogRuleRepo,
-        Job $ruleJob
+        Job $ruleJob,
+        ReconciliationGate $gate
     ) {
         $this->logger = $logger;
         $this->ruleFactory = $ruleFactory;
         $this->catalogRuleRepo = $catalogRuleRepo;
         $this->ruleJob = $ruleJob;
+        $this->gate = $gate;
+    }
+
+    /**
+     * @param ComponentMode $mode
+     *
+     * @return $this
+     */
+    public function setMode(ComponentMode $mode)
+    {
+        $this->mode = $mode;
+
+        return $this;
     }
 
     /**
@@ -127,10 +155,30 @@ class CatalogPriceRulesProcessor implements ComponentProcessorInterface
             // Get the first rule
             $rule = $ruleCollection->getFirstItem();
 
+            $version = $ruleData['version'] ?? null;
+            $request = new ReconciliationRequest(
+                'catalog_price_rules',
+                (string) $ruleData['name'],
+                $this->mode,
+                $rule->getId() !== null,
+                $version ? (int) $version : null
+            );
+
+            if ($this->gate->decide($request)->isSkip()) {
+                $this->logger->logComment(
+                    sprintf('Rule "%s" exists, skipped (create mode)', $ruleData['name']),
+                    1
+                );
+                $ite++;
+                continue;
+            }
+
             // If the rule does not exist, create a new one
             if ($rule->getId() === null) {
                 $rule = $this->ruleFactory->create();
             }
+
+            unset($ruleData['version']);
 
             /** @var Rule $rule */
             $this->fillRuleWithData($rule, $ruleData);
@@ -138,6 +186,7 @@ class CatalogPriceRulesProcessor implements ComponentProcessorInterface
             try {
                 // Save the rule
                 $this->catalogRuleRepo->save($rule);
+                $this->gate->commitVersion($request, false);
             } catch (\Exception $ex) {
                 $this->logger->logError($ex->getMessage());
             }

--- a/Component/Categories.php
+++ b/Component/Categories.php
@@ -11,11 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
-use Magebit\Configurator\Model\Processor;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\CategoryFactory;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
@@ -51,7 +53,8 @@ class Categories implements ComponentInterface
         private readonly LoggerInterface $log,
         private readonly BlockFactory $blockFactory,
         private readonly BlockResource $blockResource,
-        private readonly CategoryResource $categoryResource
+        private readonly CategoryResource $categoryResource,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -62,7 +65,7 @@ class Categories implements ComponentInterface
     {
         $result = new ComponentResult();
         $data = $context->getData();
-        $mode = $context->getMode()->value;
+        $mode = $context->getMode();
 
         if (!isset($data['categories']) || !is_array($data['categories'])) {
             $result->addError('No "categories" node found in the source data.');
@@ -127,7 +130,7 @@ class Categories implements ComponentInterface
      *
      * @param Category $parentCategory
      * @param array $categories
-     * @param string $mode
+     * @param ComponentMode $mode
      * @param bool $dryRun
      * @param ComponentResult $result
      * @return void
@@ -137,7 +140,7 @@ class Categories implements ComponentInterface
     public function createOrUpdateCategory(
         Category $parentCategory,
         array $categories,
-        string $mode,
+        ComponentMode $mode,
         bool $dryRun,
         ComponentResult $result
     ): void {
@@ -154,7 +157,16 @@ class Categories implements ComponentInterface
 
             $exists = (bool) $category->getId();
 
-            if ($exists && $mode === Processor::MODE_CREATE) {
+            $version = $categoryValues['version'] ?? null;
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                $parentCategory->getId() . '_' . $categoryValues['name'],
+                $mode,
+                $exists,
+                $version ? (int) $version : null
+            );
+
+            if ($this->gate->decide($request)->isSkip()) {
                 $this->log->logComment(sprintf("Skip category '%s' modification in create mode: ", $categoryValues['name']));
                 $result->recordSkipped();
                 continue;
@@ -231,6 +243,8 @@ class Categories implements ComponentInterface
                 );
                 $exists ? $result->recordUpdated() : $result->recordCreated();
             }
+
+            $this->gate->commitVersion($request, $dryRun);
 
             if (isset($categoryValues['categories'])) {
                 $this->createOrUpdateCategory($category, $categoryValues['categories'], $mode, $dryRun, $result);

--- a/Component/Config.php
+++ b/Component/Config.php
@@ -11,12 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
-use Magebit\Configurator\Api\VersionManagementInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
-use Magebit\Configurator\Model\Processor;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Config\Model\Config\Backend\Encrypted;
 use Magento\Config\Model\ResourceModel\Config as ConfigResource;
 use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory as ConfigCollectionFactory;
@@ -45,7 +46,7 @@ class Config implements ComponentInterface
         protected readonly WebsiteFactory $websiteFactory,
         protected readonly StoreFactory $storeFactory,
         private readonly LoggerInterface $log,
-        private readonly VersionManagementInterface $versionManagement,
+        private readonly ReconciliationGate $gate,
         private readonly ConfigCollectionFactory $configValueFactory
     ) {
     }
@@ -58,7 +59,7 @@ class Config implements ComponentInterface
     {
         $result = new ComponentResult();
         $data = $context->getData();
-        $mode = $context->getMode()->value;
+        $mode = $context->getMode();
         $dryRun = $context->isDryRun();
 
         if ($data === [] || !is_array($data)) {
@@ -179,7 +180,7 @@ class Config implements ComponentInterface
         string $path,
         mixed $value = null,
         int $encrypted = 0,
-        string $mode = Processor::MODE_MAINTAIN,
+        ComponentMode $mode = ComponentMode::Maintain,
         ?string $version = null,
         bool $dryRun = false,
         ?ComponentResult $result = null
@@ -188,13 +189,17 @@ class Config implements ComponentInterface
             // Check existing value, skip if the same
             $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
             $existingValue = $this->getSetConfigValue($path, $scope, 0);
-            $versionId = self::ALIAS . '_global_' . $path;
 
-            $isNewVersion = isset($version) && $this->versionManagement->isNewVersion($versionId, (int) $version);
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                'global_' . $path,
+                $mode,
+                (bool) $existingValue,
+                $version ? (int) $version : null,
+                $existingValue !== false && $value == $existingValue
+            );
 
-            if (($existingValue !== false && $value == $existingValue) ||
-                ($existingValue && $mode == Processor::MODE_CREATE && !$isNewVersion)
-            ) {
+            if ($this->gate->decide($request)->isSkip()) {
                 $this->log->logComment(sprintf("Global Config Already Has Value: %s = %s", $path, $existingValue));
                 $result?->recordSkipped();
                 return;
@@ -213,9 +218,7 @@ class Config implements ComponentInterface
             // Save the config
             $this->configResource->saveConfig($path, $value, $scope, 0);
             $this->log->logInfo(sprintf("Global Config: %s = %s", $path, $value));
-            if ($version) {
-                $this->versionManagement->setVersion($versionId, (int) $version);
-            }
+            $this->gate->commitVersion($request, $dryRun);
             $result?->recordCreated();
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
@@ -231,7 +234,7 @@ class Config implements ComponentInterface
         mixed $value,
         string $code,
         int $encrypted = 0,
-        string $mode = Processor::MODE_MAINTAIN,
+        ComponentMode $mode = ComponentMode::Maintain,
         ?string $version = null,
         bool $dryRun = false,
         ?ComponentResult $result = null
@@ -251,12 +254,17 @@ class Config implements ComponentInterface
 
             // Check existing value, skip if the same
             $existingValue = $this->getSetConfigValue($path, $scope, (int) $website->getId());
-            $versionId = self::ALIAS . '_website_' . $website->getId() . '_' . $path;
-            $isNewVersion = isset($version) && $this->versionManagement->isNewVersion($versionId, (int) $version);
 
-            if (($existingValue !== false && $value == $existingValue) ||
-                ($existingValue && $mode == Processor::MODE_CREATE && !$isNewVersion)
-            ) {
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                'website_' . $website->getId() . '_' . $path,
+                $mode,
+                (bool) $existingValue,
+                $version ? (int) $version : null,
+                $existingValue !== false && $value == $existingValue
+            );
+
+            if ($this->gate->decide($request)->isSkip()) {
                 $this->log->logComment(
                     sprintf("Website '%s' Config Already: %s = %s", $code, $path, $existingValue),
                     $logNest
@@ -281,9 +289,7 @@ class Config implements ComponentInterface
             // Save the config
             $this->configResource->saveConfig($path, $value, $scope, (int) $website->getId());
             $this->log->logInfo(sprintf("Website '%s' Config: %s = %s", $code, $path, $value), $logNest);
-            if ($version) {
-                $this->versionManagement->setVersion($versionId, (int) $version);
-            }
+            $this->gate->commitVersion($request, $dryRun);
             $result?->recordCreated();
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
@@ -315,7 +321,7 @@ class Config implements ComponentInterface
         mixed $value,
         string $code,
         int $encrypted = 0,
-        string $mode = Processor::MODE_MAINTAIN,
+        ComponentMode $mode = ComponentMode::Maintain,
         ?string $version = null,
         bool $dryRun = false,
         ?ComponentResult $result = null
@@ -334,11 +340,17 @@ class Config implements ComponentInterface
 
             // Check existing value, skip if the same
             $existingValue = $this->getSetConfigValue($path, $scope, (int) $storeView->getId());
-            $versionId = self::ALIAS . '_store_' . $storeView->getId() . '_' . $path;
-            $isNewVersion = isset($version) && $this->versionManagement->isNewVersion($versionId, (int) $version);
 
-            if (($existingValue !== false && $value == $existingValue) ||
-                ($existingValue && $mode == Processor::MODE_CREATE && !$isNewVersion)) {
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                'store_' . $storeView->getId() . '_' . $path,
+                $mode,
+                (bool) $existingValue,
+                $version ? (int) $version : null,
+                $existingValue !== false && $value == $existingValue
+            );
+
+            if ($this->gate->decide($request)->isSkip()) {
                 $this->log->logComment(
                     sprintf("Store '%s' Config Already: %s = %s", $code, $path, $existingValue),
                     $logNest
@@ -362,9 +374,7 @@ class Config implements ComponentInterface
 
             $this->configResource->saveConfig($path, $value, $scope, (int) $storeView->getId());
             $this->log->logInfo(sprintf("Store '%s' Config: %s = %s", $code, $path, $value), $logNest);
-            if ($version) {
-                $this->versionManagement->setVersion($versionId, (int) $version);
-            }
+            $this->gate->commitVersion($request, $dryRun);
             $result?->recordCreated();
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());

--- a/Component/CustomerAttributes.php
+++ b/Component/CustomerAttributes.php
@@ -14,6 +14,7 @@ use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
 use Magento\Customer\Model\Customer;
 use Magento\Eav\Setup\EavSetup;
 use Magento\Framework\Exception\LocalizedException;
@@ -65,9 +66,10 @@ class CustomerAttributes extends Attributes
         private readonly Attribute $attributeResource,
         LoggerInterface $log,
         AttrOptionCollectionFactory $attrOptionCollectionFactory,
-        EavConfig $eavConfig
+        EavConfig $eavConfig,
+        ReconciliationGate $gate
     ) {
-        parent::__construct($eavSetup, $attributeRepository, $log, $attrOptionCollectionFactory, $eavConfig);
+        parent::__construct($eavSetup, $attributeRepository, $log, $attrOptionCollectionFactory, $eavConfig, $gate);
         $this->attributeConfigMap = array_merge($this->attributeConfigMap, $this->customerConfigMap);
     }
 
@@ -83,7 +85,13 @@ class CustomerAttributes extends Attributes
 
         try {
             foreach ($data['customer_attributes'] as $attributeCode => $attributeConfiguration) {
-                $this->processAttribute($attributeCode, $attributeConfiguration, $context->isDryRun(), $result);
+                $this->processAttribute(
+                    $attributeCode,
+                    $attributeConfiguration,
+                    $context->getMode(),
+                    $context->isDryRun(),
+                    $result
+                );
                 $this->addAdditionalValues($attributeCode, $attributeConfiguration, $context->isDryRun());
             }
         } catch (ComponentException $e) {

--- a/Component/CustomerGroups.php
+++ b/Component/CustomerGroups.php
@@ -12,9 +12,12 @@ namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Api\Data\GroupInterfaceFactory;
 use Magento\Customer\Api\GroupRepositoryInterface;
@@ -39,7 +42,8 @@ class CustomerGroups implements ComponentInterface
         private readonly GroupInterfaceFactory $groupFactory,
         private readonly TaxClassRepositoryInterface $taxClassRepository,
         private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -79,7 +83,7 @@ class CustomerGroups implements ComponentInterface
     }
 
     /**
-     * Create a customer group, skipping creation when one with the same code exists.
+     * Create a customer group, or in maintain mode re-point its tax class.
      */
     private function createCustomerGroup(
         string $groupName,
@@ -87,34 +91,58 @@ class CustomerGroups implements ComponentInterface
         ComponentContext $context,
         ComponentResult $result
     ): void {
-        if ($this->groupExists($groupName)) {
-            $this->log->logInfo(sprintf('Customer Group "%s" already exists, creation skipped', $groupName));
+        $existing = $this->findGroup($groupName);
+        $exists = $existing !== null;
+        $unchanged = $exists && (int) $existing->getTaxClassId() === $taxClassId;
+
+        $request = new ReconciliationRequest(
+            self::ALIAS,
+            $groupName,
+            $context->getMode(),
+            $exists,
+            null,
+            $exists ? $unchanged : null
+        );
+
+        $outcome = $this->gate->decide($request);
+        if ($outcome->isSkip()) {
+            $this->log->logInfo(sprintf(
+                'Customer Group "%s" %s, skipped',
+                $groupName,
+                $unchanged ? 'unchanged' : 'protected (create mode)'
+            ));
             $result->recordSkipped();
             return;
         }
 
         if ($context->isDryRun()) {
-            $this->log->logInfo(sprintf('[dry-run] Would create Customer Group "%s"', $groupName));
-            $result->recordCreated();
+            $this->log->logInfo(sprintf('[dry-run] Would %s Customer Group "%s"', $outcome->value, $groupName));
+            $outcome->record($result);
             return;
         }
 
-        $group = $this->groupFactory->create();
+        $group = $exists ? $existing : $this->groupFactory->create();
         $group->setCode($groupName);
         $group->setTaxClassId($taxClassId);
         $this->groupRepository->save($group);
 
-        $this->log->logInfo(sprintf('Customer Group "%s" created', $groupName));
-        $result->recordCreated();
+        $this->log->logInfo(sprintf(
+            'Customer Group "%s" %s',
+            $groupName,
+            $outcome === ReconciliationOutcome::Create ? 'created' : 'updated'
+        ));
+        $outcome->record($result);
     }
 
-    private function groupExists(string $groupName): bool
+    private function findGroup(string $groupName): ?GroupInterface
     {
         $criteria = $this->searchCriteriaBuilder
             ->addFilter(GroupInterface::CODE, $groupName)
             ->create();
 
-        return $this->groupRepository->getList($criteria)->getTotalCount() > 0;
+        $items = $this->groupRepository->getList($criteria)->getItems();
+
+        return $items === [] ? null : current($items);
     }
 
     /**

--- a/Component/Customers.php
+++ b/Component/Customers.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
@@ -18,6 +19,7 @@ use Magebit\Configurator\Model\ComponentResult;
 use FireGento\FastSimpleImport\Model\ImporterFactory;
 use Magento\Customer\Api\GroupManagementInterface;
 use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Customer\Model\ResourceModel\Customer\CollectionFactory as CustomerCollectionFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\ImportExport\Model\Import;
 use Magento\Indexer\Model\IndexerFactory;
@@ -51,7 +53,8 @@ class Customers implements ComponentInterface
         protected readonly GroupManagementInterface $groupManagement,
         protected readonly SearchCriteriaBuilder $criteriaBuilder,
         protected readonly IndexerFactory $indexerFactory,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly CustomerCollectionFactory $customerCollectionFactory
     ) {
     }
 
@@ -121,7 +124,23 @@ class Customers implements ComponentInterface
             $rowIndex++;
         }
 
+        // Row-level reconciliation: in create mode drop whole customer groups
+        // (an email-bearing row plus its trailing address rows) whose email
+        // already exists. A version bump forces a full re-import; maintain
+        // re-imports (APPEND upserts). Matching is case-insensitive.
+        if ($context->getMode() === ComponentMode::Create
+            && $context->getVersion() === null
+            && $customerImport !== []
+        ) {
+            $customerImport = $this->dropExistingCustomers($customerImport, $result);
+        }
+
         $importCount = count($customerImport);
+
+        if ($importCount === 0) {
+            $this->log->logInfo('No new customers to import (all already exist in create mode).');
+            return $result;
+        }
 
         if ($context->isDryRun()) {
             $this->log->logInfo(
@@ -210,6 +229,82 @@ class Customers implements ComponentInterface
         }
 
         return $this->groupDefault;
+    }
+
+    /**
+     * Drop rows belonging to customers whose email already exists. Rows with an
+     * empty email are additional addresses for the preceding customer and follow
+     * that customer's keep/drop decision.
+     *
+     * @param array $customerImport
+     * @param ComponentResult $result
+     * @return array
+     */
+    private function dropExistingCustomers(array $customerImport, ComponentResult $result): array
+    {
+        $emails = [];
+        foreach ($customerImport as $row) {
+            $email = (string) ($row[self::CUSTOMER_EMAIL_HEADER] ?? '');
+            if ($email !== '') {
+                $emails[] = $email;
+            }
+        }
+
+        $existing = $this->loadExistingCustomerEmails($emails);
+        if ($existing === []) {
+            return $customerImport;
+        }
+
+        $kept = [];
+        $dropCurrent = false;
+        $dropped = 0;
+        foreach ($customerImport as $row) {
+            $email = (string) ($row[self::CUSTOMER_EMAIL_HEADER] ?? '');
+            if ($email !== '') {
+                // A new customer starts here; decide whether to keep the group.
+                $dropCurrent = isset($existing[strtolower($email)]);
+                if ($dropCurrent) {
+                    $result->recordSkipped();
+                }
+            }
+
+            if ($dropCurrent) {
+                $dropped++;
+                continue;
+            }
+
+            $kept[] = $row;
+        }
+
+        if ($dropped > 0) {
+            $this->log->logInfo(sprintf('Create mode: %d existing customer row(s) skipped.', $dropped));
+        }
+
+        return $kept;
+    }
+
+    /**
+     * Load the subset of given emails that already exist, as a lowercased set.
+     *
+     * @param string[] $emails
+     * @return array<string, true>
+     */
+    private function loadExistingCustomerEmails(array $emails): array
+    {
+        $emails = array_values(array_unique(array_filter($emails, static fn (string $e): bool => $e !== '')));
+        if ($emails === []) {
+            return [];
+        }
+
+        $collection = $this->customerCollectionFactory->create();
+        $collection->addFieldToFilter(self::CUSTOMER_EMAIL_HEADER, ['in' => $emails]);
+
+        $existing = [];
+        foreach ($collection as $customer) {
+            $existing[strtolower((string) $customer->getEmail())] = true;
+        }
+
+        return $existing;
     }
 
     private function reindex(): void

--- a/Component/OrderStatuses.php
+++ b/Component/OrderStatuses.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Sales\Model\Order\Status;
 use Magento\Sales\Model\Order\StatusFactory;
 use Magento\Sales\Model\ResourceModel\Order\Status as StatusResource;
@@ -32,7 +36,8 @@ class OrderStatuses implements ComponentInterface
     public function __construct(
         private readonly StatusFactory $statusFactory,
         private readonly StatusResourceFactory $statusResourceFactory,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -48,7 +53,7 @@ class OrderStatuses implements ComponentInterface
 
         foreach ($data['order_statuses'] as $statusSet) {
             try {
-                $this->createOrderStatuses($statusSet, $context->isDryRun(), $result);
+                $this->createOrderStatuses($statusSet, $context->getMode(), $context->isDryRun(), $result);
             } catch (ComponentException $e) {
                 $this->log->logError($e->getMessage());
                 $result->addError($e->getMessage());
@@ -62,38 +67,61 @@ class OrderStatuses implements ComponentInterface
      * @param array $statusSet
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      */
-    public function createOrderStatuses(array $statusSet, bool $dryRun, ComponentResult $result): void
-    {
+    public function createOrderStatuses(
+        array $statusSet,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
         foreach ($statusSet['statuses'] as $statusData) {
-            if ($dryRun) {
-                $this->log->logInfo(
-                    sprintf('[dry-run] Would create order status %s', $statusData['name'])
-                );
-                $result->recordCreated();
-                continue;
-            }
+            $code = $statusData['code'];
 
             /** @var StatusResource $statusResource */
             $statusResource = $this->statusResourceFactory->create();
             /** @var Status $status */
             $status = $this->statusFactory->create();
-            $status->setData([
-                'status' => $statusData['code'],
-                'label' => $statusData['name'],
-            ]);
+            $statusResource->load($status, $code);
+            $exists = (bool) $status->getStatus();
+
+            $version = $statusData['version'] ?? null;
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                (string) $code,
+                $mode,
+                $exists,
+                $version ? (int) $version : null
+            );
+
+            $outcome = $this->gate->decide($request);
+            if ($outcome->isSkip()) {
+                $this->log->logComment(sprintf('Order status %s exists, skipped (create mode)', $statusData['name']));
+                $result->recordSkipped();
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->log->logInfo(
+                    sprintf('[dry-run] Would %s order status %s', $outcome->value, $statusData['name'])
+                );
+                $outcome->record($result);
+                continue;
+            }
+
+            $status->setData('status', $code);
+            $status->setData('label', $statusData['name']);
 
             try {
                 $statusResource->save($status);
-            } catch (ComponentException $e) {
+                $status->assignState($statusSet['state'], false, true);
+            } catch (\Exception $e) {
                 $this->log->logError($e->getMessage());
             }
 
-            $status->assignState($statusSet['state'], false, true);
-
+            $this->gate->commitVersion($request, $dryRun);
             $this->log->logInfo(
-                sprintf('Order status %s created', $statusData['name'])
+                sprintf('Order status %s %s', $statusData['name'], $outcome->value)
             );
-            $result->recordCreated();
+            $outcome->record($result);
         }
     }
 

--- a/Component/Pages.php
+++ b/Component/Pages.php
@@ -11,13 +11,14 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
-use Magebit\Configurator\Api\VersionManagementInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Exception;
-use Magebit\Configurator\Model\Processor;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Cms\Api\Data\PageInterface;
 use Magento\Cms\Api\Data\PageInterfaceFactory;
 use Magento\Cms\Api\PageRepositoryInterface;
@@ -54,7 +55,7 @@ class Pages implements ComponentInterface
         private readonly LoggerInterface            $log,
         private readonly Filesystem                 $filesystem,
         private readonly Escaper $escaper,
-        private readonly VersionManagementInterface $versionManagement,
+        private readonly ReconciliationGate $gate,
         private readonly ObjectManagerInterface $objectManager,
         private readonly ResourceConnection $resourceConnection,
         private readonly MetadataPool $metadataPool,
@@ -74,7 +75,7 @@ class Pages implements ComponentInterface
     {
         $result = new ComponentResult();
         $data = $context->getData();
-        $mode = $context->getMode()->value;
+        $mode = $context->getMode();
 
         if (!is_array($data)) {
             $result->addError('No page data found in the source data.');
@@ -98,7 +99,7 @@ class Pages implements ComponentInterface
      *
      * @param string $identifier
      * @param array $data
-     * @param string $mode
+     * @param ComponentMode $mode
      * @param bool $dryRun
      * @param ComponentResult $result
      * @return void
@@ -108,7 +109,7 @@ class Pages implements ComponentInterface
     protected function processPage(
         string $identifier,
         array $data,
-        string $mode,
+        ComponentMode $mode,
         bool $dryRun,
         ComponentResult $result
     ): void {
@@ -124,20 +125,29 @@ class Pages implements ComponentInterface
                 }
 
                 $version = $pageData['version'] ?? null;
-                $versionId = self::ALIAS . '_' . $identifier;
 
+                // Version key preserves the legacy composition: identifier with the
+                // store codes appended (no separator) when stores are specified.
+                $versionKey = $identifier;
                 if (isset($pageData['stores'])) {
-                    $versionId .= implode('_', $pageData['stores']);
+                    $versionKey .= implode('_', $pageData['stores']);
                 }
 
                 if ($version) {
                     unset($pageData['version']);
                 }
 
+                $request = new ReconciliationRequest(
+                    self::ALIAS,
+                    $versionKey,
+                    $mode,
+                    (bool) $pageId,
+                    $version ? (int) $version : null
+                );
+
                 /** @var PageInterface $page */
                 if ($pageId) {
-                    $isNewVersion = $version && $this->versionManagement->isNewVersion($versionId, (int) $version);
-                    if ($mode === Processor::MODE_CREATE && !$isNewVersion) {
+                    if ($this->gate->decide($request)->isSkip()) {
                         $result->recordSkipped();
                         continue;
                     }
@@ -268,17 +278,7 @@ class Pages implements ComponentInterface
                     $isNew ? $result->recordCreated() : $result->recordUpdated();
                 }
 
-                if ($version) {
-                    if ($dryRun) {
-                        $this->log->logInfo(sprintf(
-                            "[dry-run] Would set version %d for %s",
-                            (int) $version,
-                            $versionId
-                        ));
-                    } else {
-                        $this->versionManagement->setVersion($versionId, (int) $version);
-                    }
-                }
+                $this->gate->commitVersion($request, $dryRun);
             }
         } catch (NoSuchEntityException $e) {
             $this->log->logError($e->getMessage());

--- a/Component/ProductLinks.php
+++ b/Component/ProductLinks.php
@@ -17,6 +17,8 @@ use Magento\Catalog\Api\Data\ProductLinkInterfaceFactory;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 
 class ProductLinks implements ComponentInterface
 {
@@ -32,7 +34,8 @@ class ProductLinks implements ComponentInterface
     public function __construct(
         private readonly ProductRepositoryInterface $productRepository,
         private readonly ProductLinkInterfaceFactory $productLinkFactory,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -120,6 +123,31 @@ class ProductLinks implements ComponentInterface
         ComponentResult $result
     ): void {
         try {
+            // Treat the (product, link type) pair as the entity: in create mode an
+            // existing set of links of this type is left untouched, so we don't
+            // overwrite live link data unless maintaining.
+            $product = $this->productRepository->get($sku);
+            $existingOfType = array_filter(
+                $product->getProductLinks(),
+                fn ($link): bool => $link->getLinkType() === $this->linkTypeMap[$linkType]
+            );
+
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                $sku . '_' . $linkType,
+                $context->getMode(),
+                $existingOfType !== []
+            );
+
+            if ($this->gate->decide($request)->isSkip()) {
+                $this->log->logComment(
+                    sprintf('Product %s already has %s links, skipped (create mode)', $sku, $linkType),
+                    1
+                );
+                $result->recordSkipped();
+                return;
+            }
+
             $productLinks = [];
 
             // Loop through all the products that require linking to a product
@@ -144,8 +172,7 @@ class ProductLinks implements ComponentInterface
                 return;
             }
 
-            // Save product links onto the main product
-            $product = $this->productRepository->get($sku);
+            // Save product links onto the main product (loaded above for the gate check)
             $product->setProductLinks($productLinks);
             $this->productRepository->save($product);
             $this->log->logComment(sprintf('Saved product links for %s', $sku), 1);

--- a/Component/Products.php
+++ b/Component/Products.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Component\Product\Image;
 use Magebit\Configurator\Component\Product\AttributeOption;
@@ -82,7 +84,8 @@ class Products implements ComponentInterface
         private readonly Image $image,
         private readonly ValidatorFactory $validatorFactory,
         private readonly AttributeOption $attributeOption,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ProductCollectionFactory $productCollectionFactory
     ) {
     }
 
@@ -147,6 +150,37 @@ class Products implements ComponentInterface
                 )
             );
         }
+
+        // Row-level reconciliation: in create mode, drop rows whose SKU already
+        // exists so we don't re-import existing products. A component-level
+        // version bump (the Processor already let us run past its source gate)
+        // forces a full re-import. Maintain always re-imports (FastSimpleImport
+        // is opaque, so we cannot cheaply diff individual attributes).
+        if ($context->getMode() === ComponentMode::Create
+            && $context->getVersion() === null
+            && $productsArray !== []
+        ) {
+            $existing = $this->loadExistingSkus($this->successProducts);
+            if ($existing !== []) {
+                $kept = [];
+                foreach ($productsArray as $row) {
+                    $sku = strtolower((string) ($row[self::SKU_COLUMN_HEADING] ?? ''));
+                    if ($sku !== '' && isset($existing[$sku])) {
+                        $result->recordSkipped();
+                        continue;
+                    }
+                    $kept[] = $row;
+                }
+                if (count($kept) !== count($productsArray)) {
+                    $this->log->logInfo(sprintf(
+                        'Create mode: %d existing product row(s) skipped.',
+                        count($productsArray) - count($kept)
+                    ));
+                }
+                $productsArray = $kept;
+            }
+        }
+
         if ($productsArray === []) {
             // Nothing survived preparation (e.g. configurable products whose
             // associated simple products don't exist yet). FastSimpleImport's
@@ -191,6 +225,32 @@ class Products implements ComponentInterface
         $this->log->logError($import->getErrorMessages());
 
         return $result;
+    }
+
+    /**
+     * Load the subset of the given SKUs that already exist, as a lowercased
+     * lookup set, in a single query. SKU matching is case-insensitive.
+     *
+     * @param string[] $skus
+     * @return array<string, true>
+     */
+    private function loadExistingSkus(array $skus): array
+    {
+        $skus = array_values(array_filter(array_map('strval', $skus), static fn (string $s): bool => $s !== ''));
+        if ($skus === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addAttributeToSelect(self::SKU_COLUMN_HEADING);
+        $collection->addFieldToFilter(self::SKU_COLUMN_HEADING, ['in' => $skus]);
+
+        $existing = [];
+        foreach ($collection as $product) {
+            $existing[strtolower((string) $product->getSku())] = true;
+        }
+
+        return $existing;
     }
 
     /**

--- a/Component/ReviewRating.php
+++ b/Component/ReviewRating.php
@@ -14,6 +14,8 @@ use Magebit\Configurator\Api\ComponentInterface;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Review\Model\Rating;
 use Magento\Review\Model\RatingFactory;
 use Magento\Review\Model\ResourceModel\Rating as RatingResource;
@@ -44,7 +46,8 @@ class ReviewRating implements ComponentInterface
         private readonly EntityFactory $entityFactory,
         private readonly RatingResource $ratingResource,
         private readonly RatingOptionResource $optionResource,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -66,10 +69,27 @@ class ReviewRating implements ComponentInterface
                 /** @var Rating $ratingModel */
                 $ratingModel = $this->getReviewRating((string) $code);
                 $existed = (bool) $ratingModel->getId();
+
+                $version = $reviewRating['version'] ?? null;
+                $request = new ReconciliationRequest(
+                    self::ALIAS,
+                    (string) $code,
+                    $context->getMode(),
+                    $existed,
+                    $version ? (int) $version : null
+                );
+
+                if ($this->gate->decide($request)->isSkip()) {
+                    $this->log->logComment(sprintf('Review rating "%s" exists, skipped (create mode)', $code));
+                    $result->recordSkipped();
+                    continue;
+                }
+
                 $ratingModel = $this->updateOrCreateRating($ratingModel, (string) $code, $reviewRating);
 
                 if ($dryRun) {
                     $this->log->logInfo(sprintf('[dry-run] Would update review rating "%s"', $code));
+                    $this->gate->commitVersion($request, $dryRun);
                     $existed ? $result->recordUpdated() : $result->recordCreated();
                     continue;
                 }
@@ -77,6 +97,7 @@ class ReviewRating implements ComponentInterface
                 $this->ratingResource->save($ratingModel);
                 $this->setOptions($ratingModel, $dryRun);
                 $this->log->logInfo((string) __('Updated review rating "%1"', $code));
+                $this->gate->commitVersion($request, $dryRun);
                 $existed ? $result->recordUpdated() : $result->recordCreated();
             } catch (\Exception $e) {
                 $this->log->logError(

--- a/Component/Rewrites.php
+++ b/Component/Rewrites.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\UrlRewrite\Model\UrlRewriteFactory;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\UrlRewrite\Model\ResourceModel\UrlRewrite as UrlRewriteResource;
@@ -41,7 +44,8 @@ class Rewrites implements ComponentInterface
         private readonly UrlPersistInterface $urlPersist,
         private readonly UrlRewriteFactory $urlRewriteFactory,
         private readonly UrlRewriteResource $urlRewriteResource,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -76,7 +80,7 @@ class Rewrites implements ComponentInterface
                     continue;
                 }
 
-                $this->createOrUpdateRewriteRule($rewriteArray, $context->isDryRun(), $result);
+                $this->createOrUpdateRewriteRule($rewriteArray, $context->getMode(), $context->isDryRun(), $result);
             } catch (ComponentException $e) {
                 $this->log->logError($e->getMessage());
                 $result->addError($e->getMessage());
@@ -132,8 +136,12 @@ class Rewrites implements ComponentInterface
      *
      * @param array $rewriteArray
      */
-    public function createOrUpdateRewriteRule(array $rewriteArray, bool $dryRun, ComponentResult $result): void
-    {
+    public function createOrUpdateRewriteRule(
+        array $rewriteArray,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
         $rewrite = $this->urlRewriteFactory->create();
         $successMessage = 'URL Rewrite: "%s" created';
         $isUpdate = false;
@@ -141,6 +149,21 @@ class Rewrites implements ComponentInterface
             ->addFieldToFilter(self::REQUEST_PATH_KEY, $rewriteArray[self::REQUEST_PATH_CSV_KEY])
             ->addFieldToFilter('store_id', $rewriteArray[self::STORE_ID_CSV_KEY])
             ->getSize();
+
+        $request = new ReconciliationRequest(
+            self::ALIAS,
+            $rewriteArray[self::REQUEST_PATH_CSV_KEY] . '_' . $rewriteArray[self::STORE_ID_CSV_KEY],
+            $mode,
+            $rewriteCount > 0
+        );
+
+        if ($this->gate->decide($request)->isSkip()) {
+            $this->log->logComment(
+                sprintf('URL Rewrite "%s" exists, skipped (create mode)', $rewriteArray[self::REQUEST_PATH_CSV_KEY])
+            );
+            $result->recordSkipped();
+            return;
+        }
 
         if ($rewriteCount > 0) {
             $rewrite = $rewrite->getCollection()

--- a/Component/TaxRates.php
+++ b/Component/TaxRates.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magento\Tax\Model\Calculation\RateFactory;
 use Magento\TaxImportExport\Model\Rate\CsvImportHandler;
 
 class TaxRates implements ComponentInterface
@@ -24,7 +26,8 @@ class TaxRates implements ComponentInterface
 
     public function __construct(
         private readonly CsvImportHandler $csvImportHandler,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly RateFactory $rateFactory
     ) {
     }
 
@@ -41,6 +44,19 @@ class TaxRates implements ComponentInterface
         try {
             // Sort data into the column order importExport requires
             $sortedData = $this->getSortedData($data);
+
+            // Row-level reconciliation: in create mode drop rows whose rate code
+            // already exists (a version bump forces a full re-import; maintain
+            // re-imports). Done before the dry-run branch so counts are accurate.
+            if ($context->getMode() === ComponentMode::Create && $context->getVersion() === null) {
+                $sortedData = $this->dropExistingRates($sortedData, $result);
+            }
+
+            // Only the header row remains -> nothing new to import.
+            if (count($sortedData) <= 1) {
+                $this->log->logInfo('No new tax rates to import (all already exist in create mode).');
+                return $result;
+            }
 
             if ($context->isDryRun()) {
                 // Bulk CSV import: skip both the temp-file write and the import.
@@ -101,6 +117,71 @@ class TaxRates implements ComponentInterface
             $sortedData[] = $rateData;
         }
         return $sortedData;
+    }
+
+    /**
+     * Drop sorted-data rows whose tax rate code already exists. The first column
+     * of each data row is the code; the header row (index 0) is always kept.
+     *
+     * @param array $sortedData
+     * @param ComponentResult $result
+     * @return array
+     */
+    protected function dropExistingRates(array $sortedData, ComponentResult $result): array
+    {
+        if (count($sortedData) <= 1) {
+            return $sortedData;
+        }
+
+        $header = $sortedData[0];
+        $rows = array_slice($sortedData, 1);
+
+        $codes = array_map(static fn (array $row): string => (string) ($row[0] ?? ''), $rows);
+        $existing = $this->loadExistingRateCodes($codes);
+        if ($existing === []) {
+            return $sortedData;
+        }
+
+        $kept = [$header];
+        $dropped = 0;
+        foreach ($rows as $row) {
+            $code = strtolower((string) ($row[0] ?? ''));
+            if ($code !== '' && isset($existing[$code])) {
+                $result->recordSkipped();
+                $dropped++;
+                continue;
+            }
+            $kept[] = $row;
+        }
+
+        if ($dropped > 0) {
+            $this->log->logInfo(sprintf('Create mode: %d existing tax rate(s) skipped.', $dropped));
+        }
+
+        return $kept;
+    }
+
+    /**
+     * Load the subset of given rate codes that already exist, lowercased.
+     *
+     * @param string[] $codes
+     * @return array<string, true>
+     */
+    private function loadExistingRateCodes(array $codes): array
+    {
+        $codes = array_values(array_unique(array_filter($codes, static fn (string $c): bool => $c !== '')));
+        if ($codes === []) {
+            return [];
+        }
+
+        $collection = $this->rateFactory->create()->getCollection()->addFieldToFilter('code', ['in' => $codes]);
+
+        $existing = [];
+        foreach ($collection as $rate) {
+            $existing[strtolower((string) $rate->getCode())] = true;
+        }
+
+        return $existing;
     }
 
     /**

--- a/Component/TaxRules.php
+++ b/Component/TaxRules.php
@@ -12,9 +12,12 @@ namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Tax\Model\Calculation\RuleFactory;
 use Magento\Tax\Model\Calculation\RateFactory;
 use Magento\Tax\Model\ClassModelFactory;
@@ -45,7 +48,8 @@ class TaxRules implements ComponentInterface
         private readonly RuleFactory $ruleFactory,
         private readonly TaxRuleResource $taxRuleResource,
         private readonly TaxClassResource $taxClassResource,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -213,11 +217,15 @@ class TaxRules implements ComponentInterface
     private function createTaxRule(array $ruleData, ComponentContext $context, ComponentResult $result): void
     {
         $rule = $this->ruleFactory->create();
-        $ruleCount = $rule->getCollection()->addFieldToFilter('code', $ruleData['code'])->getSize();
+        $existing = $rule->getCollection()->addFieldToFilter('code', $ruleData['code'])->getFirstItem();
+        $exists = (bool) $existing->getId();
 
-        if ($ruleCount > 0) {
+        $request = new ReconciliationRequest(self::ALIAS, (string) $ruleData['code'], $context->getMode(), $exists);
+
+        $outcome = $this->gate->decide($request);
+        if ($outcome->isSkip()) {
             $this->log->logComment(
-                sprintf('Tax Rule "%s" already exists in database.', $ruleData['code'])
+                sprintf('Tax Rule "%s" exists, skipped (create mode).', $ruleData['code'])
             );
             $result->recordSkipped();
 
@@ -226,13 +234,14 @@ class TaxRules implements ComponentInterface
 
         if ($context->isDryRun()) {
             $this->log->logInfo(
-                sprintf('[dry-run] Would create Tax Rule "%s".', $ruleData['code'])
+                sprintf('[dry-run] Would %s Tax Rule "%s".', $outcome->value, $ruleData['code'])
             );
-            $result->recordCreated();
+            $outcome->record($result);
 
             return;
         }
 
+        $rule = $outcome === ReconciliationOutcome::Create ? $rule : $existing;
         $rule->setCode($ruleData['code'])
             ->setTaxRateIds($ruleData['tax_rate_ids'])
             ->setCustomerTaxClassIds($ruleData['customer_tax_class_ids'])
@@ -243,9 +252,9 @@ class TaxRules implements ComponentInterface
         $this->taxRuleResource->save($rule);
 
         $this->log->logInfo(
-            sprintf('Tax Rule "%s" created.', $ruleData['code'])
+            sprintf('Tax Rule "%s" %s.', $ruleData['code'], $outcome->value)
         );
-        $result->recordCreated();
+        $outcome->record($result);
     }
 
     public function getAlias(): string

--- a/Component/Websites.php
+++ b/Component/Websites.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Store\Model\Group;
 use Magento\Store\Model\GroupFactory;
 use Magento\Store\Model\Store;
@@ -37,7 +40,8 @@ class Websites implements ComponentInterface
         private readonly WebsiteFactory $websiteFactory,
         private readonly StoreFactory $storeFactory,
         private readonly GroupFactory $groupFactory,
-        private readonly LoggerInterface $log
+        private readonly LoggerInterface $log,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -52,27 +56,28 @@ class Websites implements ComponentInterface
         }
 
         $dryRun = $context->isDryRun();
+        $mode = $context->getMode();
 
         try {
             // Loop through the websites
             foreach ($data['websites'] as $code => $websiteData) {
                 // Process the website
-                $website = $this->processWebsite($code, $websiteData, $dryRun, $result);
+                $website = $this->processWebsite($code, $websiteData, $mode, $dryRun, $result);
 
                 // Loop through the store groups
                 foreach ($websiteData['store_groups'] as $storeGroupData) {
                     // Process the store group
-                    $storeGroup = $this->processStoreGroup($storeGroupData, $website, $dryRun, $result);
+                    $storeGroup = $this->processStoreGroup($storeGroupData, $website, $mode, $dryRun, $result);
 
                     // Loop through the store views
                     foreach ($storeGroupData['store_views'] as $code => $storeViewData) {
                         // Process the store view
-                        $this->processStoreView($code, $storeViewData, $storeGroup, $dryRun, $result);
+                        $this->processStoreView($code, $storeViewData, $storeGroup, $mode, $dryRun, $result);
                     }
 
                     // As the store may not be created yet, associated the default store to the store group
                     // has to be completed after all stores for the store group have been created.
-                    $this->setDefaultStore($storeGroup, $storeGroupData, $dryRun, $result);
+                    $this->setDefaultStore($storeGroup, $storeGroupData, $mode, $dryRun, $result);
                 }
             }
 
@@ -100,7 +105,7 @@ class Websites implements ComponentInterface
      * @return Website
      * @SuppressWarnings(PHPMD)
      */
-    protected function processWebsite($code, $websiteData, bool $dryRun, ComponentResult $result)
+    protected function processWebsite($code, $websiteData, ComponentMode $mode, bool $dryRun, ComponentResult $result)
     {
         $logNest = 1;
 
@@ -109,6 +114,15 @@ class Websites implements ComponentInterface
 
             $website = $this->websiteFactory->create();
             $website->load($code, 'code');
+
+            // In create mode an existing website is returned untouched so child
+            // groups/stores can still attach, but its attributes are not modified.
+            $request = new ReconciliationRequest(self::ALIAS, 'website_' . $code, $mode, (bool) $website->getId());
+            if ($website->getId() && $this->gate->decide($request)->isSkip()) {
+                $this->log->logComment(sprintf("Website '%s' exists, skip modifying (create mode)", $code), $logNest);
+                $result->recordSkipped();
+                return $website;
+            }
 
             $canSave = false;
             $isNew = false;
@@ -177,8 +191,13 @@ class Websites implements ComponentInterface
      * @return Group
      * @SuppressWarnings(PHPMD)
      */
-    protected function processStoreGroup($storeGroupData, Website $website, bool $dryRun, ComponentResult $result)
-    {
+    protected function processStoreGroup(
+        $storeGroupData,
+        Website $website,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ) {
         $logNest = 2;
 
         try {
@@ -201,6 +220,22 @@ class Websites implements ComponentInterface
                 $storeGroup->load($storeGroupData['group_id']);
             } else {
                 $storeGroup->load($storeGroupData['name'], 'name');
+            }
+
+            // Create mode protects an existing store group from modification.
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                'group_' . ($storeGroupData['group_id'] ?? $storeGroupData['name']),
+                $mode,
+                (bool) $storeGroup->getId()
+            );
+            if ($storeGroup->getId() && $this->gate->decide($request)->isSkip()) {
+                $this->log->logComment(
+                    sprintf("Store group '%s' exists, skip modifying (create mode)", $storeGroupData['name']),
+                    $logNest
+                );
+                $result->recordSkipped();
+                return $storeGroup;
             }
 
             $canSave = false;
@@ -276,8 +311,14 @@ class Websites implements ComponentInterface
      * @return Store
      * @SuppressWarnings(PHPMD)
      */
-    protected function processStoreView($code, $storeViewData, Group $storeGroup, bool $dryRun, ComponentResult $result)
-    {
+    protected function processStoreView(
+        $code,
+        $storeViewData,
+        Group $storeGroup,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ) {
         $logNest = 3;
 
         try {
@@ -285,6 +326,14 @@ class Websites implements ComponentInterface
 
             $storeView = $this->storeFactory->create();
             $storeView->load($code, 'code');
+
+            // Create mode protects an existing store view from modification.
+            $request = new ReconciliationRequest(self::ALIAS, 'storeview_' . $code, $mode, (bool) $storeView->getId());
+            if ($storeView->getId() && $this->gate->decide($request)->isSkip()) {
+                $this->log->logComment(sprintf("Store view '%s' exists, skip modifying (create mode)", $code), $logNest);
+                $result->recordSkipped();
+                return $storeView;
+            }
 
             $canSave = false;
             $isNew = false;
@@ -362,8 +411,13 @@ class Websites implements ComponentInterface
      * @param $storeGroupData
      * @SuppressWarnings(PHPMD)
      */
-    protected function setDefaultStore(Group $storeGroup, $storeGroupData, bool $dryRun, ComponentResult $result): void
-    {
+    protected function setDefaultStore(
+        Group $storeGroup,
+        $storeGroupData,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
         $logNest = 2;
 
         try {
@@ -395,6 +449,12 @@ class Websites implements ComponentInterface
             if ($storeGroup->getDefaultStoreId() == $storeView->getId()) {
                 $this->log->logComment(
                     sprintf("No change with the default store for '%s", $storeGroup->getName()),
+                    $logNest
+                );
+            } elseif ($mode === ComponentMode::Create && $storeGroup->getDefaultStoreId()) {
+                // Create mode does not repoint an existing group's default store.
+                $this->log->logComment(
+                    sprintf("Skip changing default store for existing group '%s' (create mode)", $storeGroup->getName()),
                     $logNest
                 );
             } else {

--- a/Component/Widgets.php
+++ b/Component/Widgets.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 namespace Magebit\Configurator\Component;
 
 use Magebit\Configurator\Api\ComponentInterface;
+use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Area as AppArea;
@@ -43,7 +46,8 @@ class Widgets implements ComponentInterface
         private readonly AppState $appState,
         private readonly BlockRepositoryInterface $blockRepository,
         private readonly SearchCriteriaBuilder $criteriaBuilder,
-        private readonly WidgetInstanceResource $widgetResource
+        private readonly WidgetInstanceResource $widgetResource,
+        private readonly ReconciliationGate $gate
     ) {
     }
 
@@ -59,7 +63,7 @@ class Widgets implements ComponentInterface
 
         try {
             foreach ($data as $widgetData) {
-                $this->processWidget($widgetData, $context->isDryRun(), $result);
+                $this->processWidget($widgetData, $context->getMode(), $context->isDryRun(), $result);
             }
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());
@@ -69,15 +73,32 @@ class Widgets implements ComponentInterface
         return $result;
     }
 
-    public function processWidget(array $widgetData, bool $dryRun, ComponentResult $result): void
-    {
+    public function processWidget(
+        array $widgetData,
+        ComponentMode $mode,
+        bool $dryRun,
+        ComponentResult $result
+    ): void {
         try {
             // Capture the configured stores so block references resolve in the right scope.
             $stores = (isset($widgetData['stores']) && is_array($widgetData['stores']))
                 ? $widgetData['stores']
                 : null;
 
+            $version = $widgetData['version'] ?? null;
+            if ($version) {
+                unset($widgetData['version']);
+            }
+
             $widget = $this->findWidgetByInstanceTypeAndTitle($widgetData['instance_type'], $widgetData['title']);
+
+            $request = new ReconciliationRequest(
+                self::ALIAS,
+                $widgetData['instance_type'] . '|' . $widgetData['title'],
+                $mode,
+                $widget !== null,
+                $version ? (int) $version : null
+            );
 
             $isNew = false;
             $canSave = false;
@@ -88,6 +109,14 @@ class Widgets implements ComponentInterface
                  * @var Instance $widget
                  */
                 $widget = $this->widgetFactory->create();
+            } elseif ($this->gate->decide($request)->isSkip()) {
+                // In create mode an existing widget is left untouched (unless its version bumped).
+                $this->log->logComment(
+                    sprintf("Widget '%s' exists, skip modifying it (create mode)", $widgetData['title']),
+                    1
+                );
+                $result->recordSkipped();
+                return;
             }
 
             foreach ($widgetData as $key => $value) {
@@ -132,6 +161,7 @@ class Widgets implements ComponentInterface
                     sprintf('[dry-run] Would save Widget %s', $widget->getTitle()),
                     1
                 );
+                $this->gate->commitVersion($request, $dryRun);
                 $isNew ? $result->recordCreated() : $result->recordUpdated();
                 return;
             }
@@ -144,6 +174,7 @@ class Widgets implements ComponentInterface
             );
 
             $this->log->logInfo(sprintf("Saved Widget %s", $widget->getTitle()), 1);
+            $this->gate->commitVersion($request, $dryRun);
             $isNew ? $result->recordCreated() : $result->recordUpdated();
         } catch (ComponentException $e) {
             $this->log->logError($e->getMessage());

--- a/Model/ComponentContext.php
+++ b/Model/ComponentContext.php
@@ -37,7 +37,8 @@ class ComponentContext
         private readonly ComponentMode $mode,
         private readonly string $environment,
         private readonly bool $dryRun,
-        Closure $parser
+        Closure $parser,
+        private readonly ?int $version = null
     ) {
         $this->parser = $parser;
     }
@@ -75,5 +76,14 @@ class ComponentContext
     public function isDryRun(): bool
     {
         return $this->dryRun;
+    }
+
+    /**
+     * Component-level version declared in master.yaml (null when none). Used by
+     * bulk/imperative components for run-once-per-version behaviour.
+     */
+    public function getVersion(): ?int
+    {
+        return $this->version;
     }
 }

--- a/Model/Processor.php
+++ b/Model/Processor.php
@@ -14,6 +14,7 @@ use Magebit\Configurator\Api\ComponentInterface;
 use Magebit\Configurator\Api\ComponentListInterface;
 use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\VersionManagementInterface;
 use Magebit\Configurator\Exception\ComponentException;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
@@ -97,6 +98,11 @@ class Processor
     protected $runResult;
 
     /**
+     * @var VersionManagementInterface
+     */
+    protected $versionManagement;
+
+    /**
      * Processor constructor.
      * @param ComponentListInterface $componentList
      * @param State $state
@@ -108,7 +114,8 @@ class Processor
         LoggerInterface $logging,
         FullModuleList $fullModuleList,
         Dir $dir,
-        Manager $manager
+        Manager $manager,
+        VersionManagementInterface $versionManagement
     ) {
         $this->componentList = $componentList;
         $this->state = $state;
@@ -116,6 +123,7 @@ class Processor
         $this->fullModuleList = $fullModuleList;
         $this->dir = $dir;
         $this->manager = $manager;
+        $this->versionManagement = $versionManagement;
     }
 
     /**
@@ -315,70 +323,114 @@ class Processor
         $modeValue = $componentConfig['env'][$this->getEnvironment()]['mode'] ?? self::MODE_CREATE;
         $mode = ComponentMode::tryFrom((string) $modeValue) ?? ComponentMode::Create;
 
-        if (isset($componentConfig['sources'])) {
-            foreach ($componentConfig['sources'] as $source) {
+        // Optional component-level version: run the whole component once per version
+        // bump. Keyed in a distinct 'source_' namespace from per-entity version ids.
+        $sourceVersion = isset($componentConfig['version']) ? (int) $componentConfig['version'] : null;
+        $sourceVersionId = 'source_' . $componentAlias;
+        if ($sourceVersion !== null
+            && !$this->versionManagement->isNewVersion($sourceVersionId, $sourceVersion)
+        ) {
+            $this->log->logComment(
+                sprintf("Skipping '%s' - already at version %d", $componentAlias, $sourceVersion)
+            );
+            return;
+        }
+
+        // Only persist the source version if the component completes without a new
+        // failure, so a crashing run retries on the next deploy.
+        $errorsBefore = count($this->getRunResult()->getErrors());
+        $aborted = false;
+
+        try {
+            if (isset($componentConfig['sources'])) {
+                foreach ($componentConfig['sources'] as $source) {
+                    try {
+                        $this->executeComponentSource(
+                            $component,
+                            $componentAlias,
+                            $source,
+                            $sourceType,
+                            $mode,
+                            $sourceVersion
+                        );
+                    } catch (ComponentException $e) {
+                        if ($this->isIgnoreMissingFiles() === true) {
+                            $this->log->logInfo("Skipping file {$source} as it could not be found.");
+                            continue;
+                        }
+                        $aborted = true;
+                        throw $e;
+                    } catch (\Throwable $t) {
+                        $this->recordComponentFailure($componentAlias, $source, $t);
+                    }
+                }
+            }
+
+            // Check if there are environment specific nodes placed
+            if (!isset($componentConfig['env'])) {
+                // If not, continue to next component
+                $this->log->logComment(
+                    sprintf("No environment node for '%s' component", $componentAlias)
+                );
+                return;
+            }
+
+            // Check if there is a node for this particular environment
+            if (!isset($componentConfig['env'][$this->getEnvironment()])) {
+                // If not, continue to next component
+                $this->log->logComment(
+                    sprintf(
+                        "No '%s' environment specific node for '%s' component",
+                        $this->getEnvironment(),
+                        $componentAlias
+                    )
+                );
+                return;
+            }
+
+            // Check if there are sources for the environment
+            if (!isset($componentConfig['env'][$this->getEnvironment()]['sources'])) {
+                // If not continue
+                $this->log->logComment(
+                    sprintf(
+                        "No '%s' environment specific sources for '%s' component",
+                        $this->getEnvironment(),
+                        $componentAlias
+                    )
+                );
+                return;
+            }
+
+            // If there are sources for the environment, process them
+            foreach ((array) $componentConfig['env'][$this->getEnvironment()]['sources'] as $source) {
                 try {
-                    $this->executeComponentSource($component, $componentAlias, $source, $sourceType, $mode);
+                    $sourceType = (isset($componentConfig['type']) === true) ? $componentConfig['type'] : null;
+                    $this->executeComponentSource(
+                        $component,
+                        $componentAlias,
+                        $source,
+                        $sourceType,
+                        $mode,
+                        $sourceVersion
+                    );
                 } catch (ComponentException $e) {
                     if ($this->isIgnoreMissingFiles() === true) {
                         $this->log->logInfo("Skipping file {$source} as it could not be found.");
                         continue;
                     }
+                    $aborted = true;
                     throw $e;
                 } catch (\Throwable $t) {
                     $this->recordComponentFailure($componentAlias, $source, $t);
                 }
             }
-        }
-
-        // Check if there are environment specific nodes placed
-        if (!isset($componentConfig['env'])) {
-            // If not, continue to next component
-            $this->log->logComment(
-                sprintf("No environment node for '%s' component", $componentAlias)
-            );
-            return;
-        }
-
-        // Check if there is a node for this particular environment
-        if (!isset($componentConfig['env'][$this->getEnvironment()])) {
-            // If not, continue to next component
-            $this->log->logComment(
-                sprintf(
-                    "No '%s' environment specific node for '%s' component",
-                    $this->getEnvironment(),
-                    $componentAlias
-                )
-            );
-            return;
-        }
-
-        // Check if there are sources for the environment
-        if (!isset($componentConfig['env'][$this->getEnvironment()]['sources'])) {
-            // If not continue
-            $this->log->logComment(
-                sprintf(
-                    "No '%s' environment specific sources for '%s' component",
-                    $this->getEnvironment(),
-                    $componentAlias
-                )
-            );
-            return;
-        }
-
-        // If there are sources for the environment, process them
-        foreach ((array) $componentConfig['env'][$this->getEnvironment()]['sources'] as $source) {
-            try {
-                $sourceType = (isset($componentConfig['type']) === true) ? $componentConfig['type'] : null;
-                $this->executeComponentSource($component, $componentAlias, $source, $sourceType, $mode);
-            } catch (ComponentException $e) {
-                if ($this->isIgnoreMissingFiles() === true) {
-                    $this->log->logInfo("Skipping file {$source} as it could not be found.");
-                    continue;
-                }
-                throw $e;
-            } catch (\Throwable $t) {
-                $this->recordComponentFailure($componentAlias, $source, $t);
+        } finally {
+            if (!$aborted
+                && $sourceVersion !== null
+                && !$this->dryRun
+                && count($this->getRunResult()->getErrors()) === $errorsBefore
+            ) {
+                $this->versionManagement->setVersion($sourceVersionId, $sourceVersion);
             }
         }
     }
@@ -423,14 +475,16 @@ class Processor
         $componentAlias,
         $source,
         $sourceType,
-        ComponentMode $mode
+        ComponentMode $mode,
+        ?int $version = null
     ): void {
         $context = new ComponentContext(
             (string) $source,
             $mode,
             $this->getEnvironment(),
             $this->dryRun,
-            fn (string $path): array => $this->parseData($path, $sourceType)
+            fn (string $path): array => $this->parseData($path, $sourceType),
+            $version
         );
 
         $result = $component->execute($context);

--- a/Model/Reconciliation/ReconciliationGate.php
+++ b/Model/Reconciliation/ReconciliationGate.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright (c) 2016 CTI Digital
+ * Copyright (c) 2026 Magebit, Ltd.
+ *
+ * Licensed under the MIT License; see the LICENSE file in the project root.
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\Configurator\Model\Reconciliation;
+
+use Magebit\Configurator\Api\ComponentMode;
+use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
+use Magebit\Configurator\Api\VersionManagementInterface;
+
+/**
+ * Single source of truth for how every component reconciles config against
+ * existing data, combining run mode and per-entity versioning.
+ *
+ * The decision table the gate encodes:
+ *
+ *   | state                              | create mode | maintain mode |
+ *   |------------------------------------|-------------|---------------|
+ *   | not exists                         | Create      | Create        |
+ *   | exists, unchanged                  | Skip        | Skip          |
+ *   | exists, changed, version bumped    | Update      | Update        |
+ *   | exists, changed, no version bump   | Skip        | Update        |
+ *
+ * Components keep their own load/diff/save mechanics; the gate only decides
+ * intent and owns version persistence.
+ */
+class ReconciliationGate
+{
+    public function __construct(
+        private readonly VersionManagementInterface $versionManagement,
+        private readonly LoggerInterface $log
+    ) {
+    }
+
+    /**
+     * The id under which this entity's version is tracked. VersionManagement
+     * adds its own CONFIG_PREFIX ('version_') on top of this.
+     */
+    public function versionId(ReconciliationRequest $request): string
+    {
+        return $request->alias . '_' . $request->key;
+    }
+
+    public function isNewVersion(ReconciliationRequest $request): bool
+    {
+        return $request->version !== null
+            && $this->versionManagement->isNewVersion($this->versionId($request), $request->version);
+    }
+
+    /**
+     * Decide what the component should do with this entity.
+     */
+    public function decide(ReconciliationRequest $request): ReconciliationOutcome
+    {
+        if (!$request->exists) {
+            return ReconciliationOutcome::Create;
+        }
+
+        // An unchanged entity is always skipped, in either mode. A null means
+        // the caller could not cheaply diff, so we do not skip on this basis.
+        if ($request->unchanged === true) {
+            return ReconciliationOutcome::Skip;
+        }
+
+        // In create mode existing entities are protected unless their version bumped.
+        if ($request->mode === ComponentMode::Create && !$this->isNewVersion($request)) {
+            return ReconciliationOutcome::Skip;
+        }
+
+        return ReconciliationOutcome::Update;
+    }
+
+    /**
+     * Persist the entity's version after a successful save. No-op when no
+     * version is declared; never writes during a dry run.
+     */
+    public function commitVersion(ReconciliationRequest $request, bool $dryRun): void
+    {
+        if ($request->version === null) {
+            return;
+        }
+
+        $id = $this->versionId($request);
+
+        if ($dryRun) {
+            $this->log->logInfo(sprintf('[dry-run] Would set version %d for %s', $request->version, $id));
+            return;
+        }
+
+        $this->versionManagement->setVersion($id, $request->version);
+    }
+}

--- a/Model/Reconciliation/ReconciliationGate.php
+++ b/Model/Reconciliation/ReconciliationGate.php
@@ -59,14 +59,16 @@ class ReconciliationGate
      */
     public function decide(ReconciliationRequest $request): ReconciliationOutcome
     {
-        if (!$request->exists) {
-            return ReconciliationOutcome::Create;
-        }
-
-        // An unchanged entity is always skipped, in either mode. A null means
-        // the caller could not cheaply diff, so we do not skip on this basis.
+        // An entity that already matches the config is always skipped, in either
+        // mode. Checked first so it holds regardless of how the caller measures
+        // existence. A null means the caller could not cheaply diff, so we do not
+        // skip on this basis and let the component run its own field diff.
         if ($request->unchanged === true) {
             return ReconciliationOutcome::Skip;
+        }
+
+        if (!$request->exists) {
+            return ReconciliationOutcome::Create;
         }
 
         // In create mode existing entities are protected unless their version bumped.

--- a/Model/Reconciliation/ReconciliationRequest.php
+++ b/Model/Reconciliation/ReconciliationRequest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) 2016 CTI Digital
+ * Copyright (c) 2026 Magebit, Ltd.
+ *
+ * Licensed under the MIT License; see the LICENSE file in the project root.
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\Configurator\Model\Reconciliation;
+
+use Magebit\Configurator\Api\ComponentMode;
+
+/**
+ * Immutable description of a single entity a component is about to reconcile.
+ * Bundled into one object so the gate's signature stays stable as inputs grow.
+ */
+final class ReconciliationRequest
+{
+    /**
+     * @param string $alias Component alias, e.g. 'config'. Prefixed onto the version id.
+     * @param string $key Scope-qualified entity key WITHOUT the alias prefix
+     *                    (e.g. 'global_web/secure/base_url', a CMS block identifier).
+     * @param ComponentMode $mode Resolved run mode for this component.
+     * @param bool $exists Whether the entity already exists in the store.
+     * @param int|null $version Desired version from config, or null when none is declared.
+     * @param bool|null $unchanged True/false when the caller can cheaply diff; null when
+     *                             it cannot (the gate then never skips on this basis and the
+     *                             component does its own field diff after deciding intent).
+     */
+    public function __construct(
+        public readonly string $alias,
+        public readonly string $key,
+        public readonly ComponentMode $mode,
+        public readonly bool $exists,
+        public readonly ?int $version = null,
+        public readonly ?bool $unchanged = null
+    ) {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,48 @@ bin/magento configurator:run --env="local" -i                   # ignore missing
 bin/magento configurator:run --env="local" -v                   # verbose logging
 ```
 
+## Reconciliation: modes & versioning
+
+Every component now applies the **same** rule for how config reconciles against
+existing data, via a shared `ReconciliationGate`:
+
+| state | `create` mode | `maintain` mode |
+|-------|---------------|-----------------|
+| entity does not exist | create | create |
+| exists, matches config | skip | skip |
+| exists, differs, version bumped | update | update |
+| exists, differs, no version bump | **skip** (protected) | update |
+
+Set the mode per environment in `master.yaml`:
+
+```yaml
+config:
+  enabled: 1
+  sources: [ ../configurator/Config/config.yaml ]
+  env:
+    production: { mode: create }    # safe: only new entities + version bumps
+    staging:    { mode: maintain }  # reconcile drift
+```
+
+When no `mode` is set the default is **`create`**.
+
+**Versioning** forces an update even in create mode:
+- **Per-entity** — add `version: <n>` to an entity in its source file (supported
+  where the data shape has per-entity nodes: config values, blocks, pages,
+  widgets, attributes, …). Bump it to push that one change to production.
+- **Per-component** — add `version: <n>` at the component level in `master.yaml`
+  to run the *whole* component once per version (ideal for `sql`, `sequence`,
+  `media`, and bulk importers like `tiered_prices` / `shippingtablerates`).
+
+> **⚠ Upgrade behavior change (v2 reconciliation):** components that previously
+> overwrote existing entities on every run (widgets, attributes, websites,
+> rewrites, product links, catalog price rules, admin roles, review ratings, …)
+> now honor mode uniformly. In `create` mode they **protect existing entities**.
+> If you relied on always-overwrite, set `mode: maintain` for those components.
+> Bulk importers (`products`, `customers`, `taxrates`) skip rows whose key
+> already exists in create mode; they do not diff individual attributes, so
+> `maintain` re-imports every row.
+
 ## Configuration reference
 
 See [`docs/schema/`](docs/schema/README.md) for the source format of every
@@ -77,7 +119,8 @@ public contract for the v2 line.
 ## Components
 
 All components are implemented and execute-verified on Magento 2.4.7. Each links
-to its schema page.
+to its schema page. **Every component honors `create`/`maintain` mode and the
+versioning levers** described above — the notes below only call out extras.
 
 | Component | Alias | Notes |
 |-----------|-------|-------|
@@ -87,7 +130,7 @@ to its schema page.
 | Attributes | `attributes` | create/maintain, swatches |
 | Attribute Sets | `attribute_sets` | |
 | Categories | `categories` | create/maintain |
-| Products | `products` | FastSimpleImport (configurable products need their simple products to exist) |
+| Products | `products` | FastSimpleImport; create mode skips existing SKUs (configurable products need their simple products to exist) |
 | Blocks | `blocks` | create/maintain, phtml templates, versioning |
 | Pages | `pages` | create/maintain, versioning |
 | API Integrations | `apiintegrations` | |
@@ -101,10 +144,10 @@ to its schema page.
 | Review Ratings | `review_rating` | |
 | Product Links | `product_links` | related / up-sell / cross-sell |
 | Customer Attributes | `customer_attributes` | |
-| Customers | `customers` | FastSimpleImport |
+| Customers | `customers` | FastSimpleImport; create mode skips existing emails |
 | SQL | `sql` | raw SQL files |
 | Catalog Price Rules | `catalog_price_rules` | |
-| Shipping Table Rates | `shippingtablerates` | |
+| Shipping Table Rates | `shippingtablerates` | gate via component-level `version:` (no per-row reconcile) |
 | Order Statuses | `order_statuses` | |
 | Tiered Prices | `tiered_prices` | FastSimpleImport |
 

--- a/Test/Unit/Component/CustomerGroupsTest.php
+++ b/Test/Unit/Component/CustomerGroupsTest.php
@@ -12,9 +12,11 @@ namespace Magebit\Configurator\Test\Unit\Component;
 
 use Magebit\Configurator\Api\ComponentMode;
 use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\VersionManagementInterface;
 use Magebit\Configurator\Component\CustomerGroups;
 use Magebit\Configurator\Model\ComponentContext;
 use Magebit\Configurator\Model\ComponentResult;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
 use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Api\Data\GroupInterfaceFactory;
 use Magento\Customer\Api\GroupRepositoryInterface;
@@ -51,19 +53,25 @@ class CustomerGroupsTest extends TestCase
         $this->searchCriteriaBuilder->method('addFilter')->willReturnSelf();
         $this->searchCriteriaBuilder->method('create')->willReturn($this->createMock(SearchCriteria::class));
 
+        // Real gate over a version store that always reports "not newer".
+        $versionManagement = $this->createMock(VersionManagementInterface::class);
+        $versionManagement->method('isNewVersion')->willReturn(false);
+        $gate = new ReconciliationGate($versionManagement, $this->log);
+
         $this->component = new CustomerGroups(
             $this->groupRepository,
             $this->groupFactory,
             $this->taxClassRepository,
             $this->searchCriteriaBuilder,
-            $this->log
+            $this->log,
+            $gate
         );
     }
 
     public function testCreatesGroupWhenItDoesNotExist(): void
     {
         $this->givenTaxClassExists(3);
-        $this->givenGroupCount(0);
+        $this->givenNoExistingGroup();
 
         $group = $this->createMock(GroupInterface::class);
         $group->expects($this->once())->method('setCode')->with('VIP')->willReturnSelf();
@@ -80,10 +88,11 @@ class CustomerGroupsTest extends TestCase
         $this->assertSame(1, $result->getCreated());
     }
 
-    public function testSkipsExistingGroup(): void
+    public function testCreateModeProtectsExistingGroup(): void
     {
         $this->givenTaxClassExists(3);
-        $this->givenGroupCount(1);
+        // Existing group with a DIFFERENT tax class — create mode must still skip it.
+        $this->givenExistingGroup(99);
 
         $this->groupFactory->expects($this->never())->method('create');
         $this->groupRepository->expects($this->never())->method('save');
@@ -92,15 +101,48 @@ class CustomerGroupsTest extends TestCase
             ['taxclass' => 'Retail Customer', 'groups' => [['name' => 'VIP']]],
         ]);
 
-        $this->assertTrue($result->isSuccessful());
         $this->assertSame(0, $result->getCreated());
+        $this->assertSame(1, $result->getSkipped());
+    }
+
+    public function testMaintainModeUpdatesExistingTaxClass(): void
+    {
+        $this->givenTaxClassExists(3);
+        $existing = $this->givenExistingGroup(99);
+
+        // Maintain mode re-points the existing group's tax class to the configured one.
+        $existing->expects($this->once())->method('setTaxClassId')->with(3)->willReturnSelf();
+        $existing->method('setCode')->willReturnSelf();
+        $this->groupFactory->expects($this->never())->method('create');
+        $this->groupRepository->expects($this->once())->method('save')->with($existing);
+
+        $result = $this->execute([
+            ['taxclass' => 'Retail Customer', 'groups' => [['name' => 'VIP']]],
+        ], false, null, ComponentMode::Maintain);
+
+        $this->assertSame(0, $result->getCreated());
+        $this->assertSame(1, $result->getUpdated());
+    }
+
+    public function testMaintainModeSkipsUnchangedGroup(): void
+    {
+        $this->givenTaxClassExists(3);
+        // Existing group already on the configured tax class -> unchanged -> skip.
+        $this->givenExistingGroup(3);
+
+        $this->groupRepository->expects($this->never())->method('save');
+
+        $result = $this->execute([
+            ['taxclass' => 'Retail Customer', 'groups' => [['name' => 'VIP']]],
+        ], false, null, ComponentMode::Maintain);
+
         $this->assertSame(1, $result->getSkipped());
     }
 
     public function testDryRunDoesNotPersist(): void
     {
         $this->givenTaxClassExists(3);
-        $this->givenGroupCount(0);
+        $this->givenNoExistingGroup();
         $this->groupFactory->method('create')->willReturn($this->createMock(GroupInterface::class));
 
         $this->groupRepository->expects($this->never())->method('save');
@@ -129,7 +171,7 @@ class CustomerGroupsTest extends TestCase
     public function testRejectsMissingAndOverlongNames(): void
     {
         $this->givenTaxClassExists(3);
-        $this->givenGroupCount(0);
+        $this->givenNoExistingGroup();
         $this->groupFactory->method('create')->willReturn($this->createMock(GroupInterface::class));
 
         // Missing name + 33-char name are both rejected; the valid one is still saved.
@@ -160,10 +202,14 @@ class CustomerGroupsTest extends TestCase
      * @param array $customerGroups value of the `customergroups` node
      * @param array|null $rawData full source override (bypasses $customerGroups)
      */
-    private function execute(array $customerGroups, bool $dryRun = false, ?array $rawData = null): ComponentResult
-    {
+    private function execute(
+        array $customerGroups,
+        bool $dryRun = false,
+        ?array $rawData = null,
+        ComponentMode $mode = ComponentMode::Create
+    ): ComponentResult {
         $data = $rawData ?? ['customergroups' => $customerGroups];
-        $context = new ComponentContext('test.yaml', ComponentMode::Create, 'test', $dryRun, static fn (): array => $data);
+        $context = new ComponentContext('test.yaml', $mode, 'test', $dryRun, static fn (): array => $data);
 
         return $this->component->execute($context);
     }
@@ -185,10 +231,22 @@ class CustomerGroupsTest extends TestCase
         $this->taxClassRepository->method('getList')->willReturn($results);
     }
 
-    private function givenGroupCount(int $count): void
+    private function givenNoExistingGroup(): void
     {
         $results = $this->createMock(GroupSearchResultsInterface::class);
-        $results->method('getTotalCount')->willReturn($count);
+        $results->method('getItems')->willReturn([]);
         $this->groupRepository->method('getList')->willReturn($results);
+    }
+
+    private function givenExistingGroup(int $taxClassId): GroupInterface&MockObject
+    {
+        $group = $this->createMock(GroupInterface::class);
+        $group->method('getTaxClassId')->willReturn($taxClassId);
+
+        $results = $this->createMock(GroupSearchResultsInterface::class);
+        $results->method('getItems')->willReturn([$group]);
+        $this->groupRepository->method('getList')->willReturn($results);
+
+        return $group;
     }
 }

--- a/Test/Unit/Model/Reconciliation/ReconciliationGateTest.php
+++ b/Test/Unit/Model/Reconciliation/ReconciliationGateTest.php
@@ -87,6 +87,15 @@ class ReconciliationGateTest extends TestCase
         $this->assertSame(ReconciliationOutcome::Skip, $this->gate->decide($request));
     }
 
+    public function testUnchangedShortCircuitsEvenWhenExistsIsFalse(): void
+    {
+        // Config maps an existing-but-empty value as exists=false yet unchanged=true;
+        // the gate must still skip (the value already matches).
+        $request = new ReconciliationRequest('config', 'global_k', ComponentMode::Maintain, false, null, true);
+
+        $this->assertSame(ReconciliationOutcome::Skip, $this->gate->decide($request));
+    }
+
     public function testUnknownDiffDoesNotSkipOnUnchangedBasis(): void
     {
         // unchanged = null (caller can't tell) -> must not be treated as unchanged.

--- a/Test/Unit/Model/Reconciliation/ReconciliationGateTest.php
+++ b/Test/Unit/Model/Reconciliation/ReconciliationGateTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright (c) 2016 CTI Digital
+ * Copyright (c) 2026 Magebit, Ltd.
+ *
+ * Licensed under the MIT License; see the LICENSE file in the project root.
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\Configurator\Test\Unit\Model\Reconciliation;
+
+use Magebit\Configurator\Api\ComponentMode;
+use Magebit\Configurator\Api\LoggerInterface;
+use Magebit\Configurator\Api\ReconciliationOutcome;
+use Magebit\Configurator\Api\VersionManagementInterface;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationGate;
+use Magebit\Configurator\Model\Reconciliation\ReconciliationRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ReconciliationGateTest extends TestCase
+{
+    private VersionManagementInterface&MockObject $versionManagement;
+    private LoggerInterface&MockObject $log;
+    private ReconciliationGate $gate;
+
+    protected function setUp(): void
+    {
+        $this->versionManagement = $this->createMock(VersionManagementInterface::class);
+        $this->log = $this->createMock(LoggerInterface::class);
+        $this->gate = new ReconciliationGate($this->versionManagement, $this->log);
+    }
+
+    public function testVersionIdComposesAliasAndKey(): void
+    {
+        $request = new ReconciliationRequest('config', 'global_web/secure/base_url', ComponentMode::Maintain, true);
+
+        $this->assertSame('config_global_web/secure/base_url', $this->gate->versionId($request));
+    }
+
+    public function testMissingEntityIsAlwaysCreate(): void
+    {
+        foreach ([ComponentMode::Create, ComponentMode::Maintain] as $mode) {
+            $request = new ReconciliationRequest('widgets', 'k', $mode, false);
+            $this->assertSame(ReconciliationOutcome::Create, $this->gate->decide($request));
+        }
+    }
+
+    public function testUnchangedEntityIsAlwaysSkip(): void
+    {
+        foreach ([ComponentMode::Create, ComponentMode::Maintain] as $mode) {
+            $request = new ReconciliationRequest('widgets', 'k', $mode, true, null, true);
+            $this->assertSame(ReconciliationOutcome::Skip, $this->gate->decide($request));
+        }
+    }
+
+    public function testExistingChangedInCreateModeIsSkipped(): void
+    {
+        $request = new ReconciliationRequest('widgets', 'k', ComponentMode::Create, true, null, false);
+
+        $this->assertSame(ReconciliationOutcome::Skip, $this->gate->decide($request));
+    }
+
+    public function testExistingChangedInMaintainModeIsUpdated(): void
+    {
+        $request = new ReconciliationRequest('widgets', 'k', ComponentMode::Maintain, true, null, false);
+
+        $this->assertSame(ReconciliationOutcome::Update, $this->gate->decide($request));
+    }
+
+    public function testVersionBumpForcesUpdateEvenInCreateMode(): void
+    {
+        $this->versionManagement->method('isNewVersion')->with('widgets_k', 5)->willReturn(true);
+
+        $request = new ReconciliationRequest('widgets', 'k', ComponentMode::Create, true, 5, false);
+
+        $this->assertSame(ReconciliationOutcome::Update, $this->gate->decide($request));
+    }
+
+    public function testStaleVersionInCreateModeIsStillSkipped(): void
+    {
+        $this->versionManagement->method('isNewVersion')->with('widgets_k', 5)->willReturn(false);
+
+        $request = new ReconciliationRequest('widgets', 'k', ComponentMode::Create, true, 5, false);
+
+        $this->assertSame(ReconciliationOutcome::Skip, $this->gate->decide($request));
+    }
+
+    public function testUnknownDiffDoesNotSkipOnUnchangedBasis(): void
+    {
+        // unchanged = null (caller can't tell) -> must not be treated as unchanged.
+        $request = new ReconciliationRequest('widgets', 'k', ComponentMode::Maintain, true, null, null);
+
+        $this->assertSame(ReconciliationOutcome::Update, $this->gate->decide($request));
+    }
+
+    public function testCommitVersionPersistsWhenNotDryRun(): void
+    {
+        $this->versionManagement->expects($this->once())->method('setVersion')->with('config_global_k', 7);
+
+        $request = new ReconciliationRequest('config', 'global_k', ComponentMode::Maintain, true, 7);
+        $this->gate->commitVersion($request, false);
+    }
+
+    public function testCommitVersionNeverPersistsDuringDryRun(): void
+    {
+        $this->versionManagement->expects($this->never())->method('setVersion');
+
+        $request = new ReconciliationRequest('config', 'global_k', ComponentMode::Maintain, true, 7);
+        $this->gate->commitVersion($request, true);
+    }
+
+    public function testCommitVersionIsNoOpWhenNoVersionDeclared(): void
+    {
+        $this->versionManagement->expects($this->never())->method('setVersion');
+
+        $request = new ReconciliationRequest('config', 'global_k', ComponentMode::Maintain, true, null);
+        $this->gate->commitVersion($request, false);
+    }
+}


### PR DESCRIPTION
Batch B from the team-feedback thread. Makes create/maintain mode + versioning **consistent across every component** via a shared decision service — the root fix for Deniss's "components ignore --env and rewrite live data" and Aigars's "create/maintain feels overcomplicated" (it wasn't overcomplicated, it was only half-implemented: 4/30 components honored mode, 3/30 honored versioning).

> **Stacked on #29** (Batch A). Base is `v2-store-scope-fixes`; retarget to `magebit` once #29 merges.

## The model

One shared `ReconciliationGate` encodes the rule every component now follows:

| state | create | maintain |
|---|---|---|
| not exists | create | create |
| exists, unchanged | skip | skip |
| exists, changed, version bumped | update | update |
| exists, changed, no bump | **skip** (protected) | update |

Plus two version levers: **per-entity** `version:` (force one entity) and **per-component** `version:` in master.yaml (run the whole component once per version — for SQL/imperative/bulk).

## Waves (one commit each)

- **0** — `ReconciliationGate` + `ReconciliationOutcome` enum + `ReconciliationRequest` (12 unit tests).
- **1** — refactor Blocks/Config/Pages onto the gate (pure refactor, byte-identical version keys).
- **2** — 10 always-updating reconcilers honor mode (Widgets, Attributes, CatalogPriceRules, Websites, ReviewRating, Rewrites, ProductLinks, AdminRoles, Categories, CustomerAttributes).
- **3** — 5 create-only reconcilers gain update-in-maintain (CustomerGroups, AdminUsers, TaxRules, AttributeSets, ApiIntegrations — token-safe, never re-mints; AdminUsers never re-sets password).
- **4** — OrderStatuses becomes an entity-reconciler (fixes dup-key crash on re-run).
- **5** — Processor source-level version gate + `ComponentContext::getVersion()`.
- **6** — bulk row-gating: Products/Customers/TaxRates skip existing keys in create mode (with the empty-import guard preserved); TieredPrices/ShippingTableRates use the component version gate.

## ⚠ Behavior change on upgrade

Components that previously overwrote existing entities every run now **protect them in create mode**. Set `mode: maintain` to keep reconciling. Documented in the README's new "Reconciliation" section.

## Verification (Magento 2.4.7-p3 / PHP 8.3)

- Unit suite **20/20** (gate decision table, dry-run-never-persists, CustomerGroups create-protect / maintain-update / unchanged-skip).
- `setup:di:compile` clean (every new constructor dep wired).
- Conformance harness **PASS** at each wave; skipped count rises as create-protect engages — no crashes.

## Honest limitations

- Bulk importers don't diff individual attributes (FastSimpleImport/CsvImportHandler are opaque) — maintain re-imports every row.
- TieredPrices/ShippingTableRates have no cheap per-row key → version-gate only.
- The per-component version *persist* path runs only in real (non-dry-run) deploys, so it's exercised by deployment, not the dry-run conformance harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)