### PR TITLE
v2: sync-from-db exports the full entity for the remaining components

### DIFF
--- a/Component/AdminUsers.php
+++ b/Component/AdminUsers.php
@@ -212,12 +212,16 @@ class AdminUsers implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
-     * Export current admin users into the source format. Refresh mode rewrites
-     * only the role sets / users already tracked in the source file, pulling each
-     * tracked user's current fields from the DB (matched by email); a tracked user
-     * that no longer exists is kept untouched. Full mode dumps every admin user,
-     * grouped by their assigned role's name (optionally filtered by role-name
-     * prefix). The password is a secret and is never written out.
+     * Export current admin users into the source format. Refresh mode re-reads
+     * every tracked user's full current state from the DB (matched by email):
+     * all value fields (username/firstname/secondname/email, optional
+     * interface_locale) plus the `role` relation, which is re-resolved so the
+     * user is regrouped under its current role's name — admin changes to either a
+     * field or the assigned role are captured, not just the keys already tracked.
+     * A tracked user that no longer exists is kept untouched under its original
+     * role set. Full mode dumps every admin user, grouped by their assigned
+     * role's name (optionally filtered by role-name prefix). The password is a
+     * secret and is never written out.
      */
     public function export(ExportContext $context): array
     {
@@ -227,9 +231,11 @@ class AdminUsers implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
-     * Refresh each tracked user's value fields from the DB (matched by email),
-     * preserving any other keys (version, interface_locale) and the role grouping.
-     * Users with no matching DB record are kept exactly as they are in the source.
+     * Re-read each tracked user's full current state from the DB (matched by
+     * email), re-resolving the `role` relation so users land under their current
+     * role's name. Users with no matching DB record are kept exactly as they are
+     * in the source, under their original role set. Role sets that hold no tracked
+     * users (or are malformed) are preserved as-is so non-user keys survive.
      *
      * @param array $existing
      * @return array
@@ -241,50 +247,96 @@ class AdminUsers implements ComponentInterface, ExportableComponentInterface
         }
 
         $out = $existing;
+
+        // Index role sets by name so a user whose role changed in the DB can be
+        // moved into the matching tracked role set (when one exists).
+        $roleSetIndex = [];
+        foreach ($existing['adminusers'] as $i => $roleSet) {
+            if (is_array($roleSet) && isset($roleSet['rolename'])) {
+                $roleSetIndex[(string) $roleSet['rolename']] = $i;
+            }
+        }
+
+        // Pass 1: strip every tracked user from its source role set, refreshing
+        // each one's full state (or keeping it untouched when it no longer exists).
+        // Collect the refreshed entries together with their current DB role name.
+        $refreshed = [];
         foreach ($existing['adminusers'] as $i => $roleSet) {
             if (!is_array($roleSet) || !isset($roleSet['users']) || !is_array($roleSet['users'])) {
                 continue;
             }
 
-            $users = [];
+            $keep = [];
             foreach ($roleSet['users'] as $userData) {
                 $email = is_array($userData) ? ($userData['email'] ?? null) : null;
-                $current = $email !== null ? $this->loadUserByEmail((string) $email) : null;
+                $user = $email !== null ? $this->loadUserByEmail((string) $email) : null;
 
-                if ($current === null) {
-                    $users[] = $userData;
+                if ($user === null) {
+                    // No matching DB record: keep the source entry where it is.
+                    $keep[] = $userData;
                     continue;
                 }
 
-                $users[] = $this->refreshUserEntry((array) $userData, $current);
+                $refreshed[] = [
+                    'rolename' => $this->getRoleNameForUser($user),
+                    'entry' => $this->refreshUserEntry((array) $userData, $user),
+                ];
             }
 
-            $out['adminusers'][$i]['users'] = $users;
+            $out['adminusers'][$i]['users'] = $keep;
+        }
+
+        // Pass 2: place each refreshed user under its current role's role set,
+        // creating a new role set when the role isn't already tracked.
+        foreach ($refreshed as $item) {
+            $roleName = $item['rolename'];
+
+            if ($roleName === null) {
+                continue;
+            }
+
+            if (!isset($roleSetIndex[$roleName])) {
+                $out['adminusers'][] = ['rolename' => $roleName, 'users' => []];
+                $roleSetIndex[$roleName] = array_key_last($out['adminusers']);
+            }
+
+            $out['adminusers'][$roleSetIndex[$roleName]]['users'][] = $item['entry'];
         }
 
         return $out;
     }
 
     /**
-     * Rebuild a tracked user entry from its current DB values, preserving any
-     * non-value keys already present in the source (e.g. version). The password
-     * is never written out.
+     * Rebuild a tracked user entry from its full current DB state, dropping stale
+     * keys not backed by a current value and preserving any non-DB structural keys
+     * already present in the source (e.g. version). Null/empty values are skipped
+     * to keep the file clean. The password is never written out.
      *
-     * @param array $entry
-     * @param array $values Current DB values keyed by source field.
+     * @param array $entry Existing tracked source entry.
+     * @param mixed $user Loaded admin user model.
      * @return array
      */
-    private function refreshUserEntry(array $entry, array $values): array
+    private function refreshUserEntry(array $entry, $user): array
     {
-        unset($entry['password']);
+        // Reuse the full-export builder so a tracked user comes back with its
+        // complete current field set, not just the keys the source already lists.
+        $fresh = $this->userToEntry($user);
 
-        foreach ($values as $key => $value) {
-            if ($value !== null) {
-                $entry[$key] = $value;
+        // Carry over non-DB structural keys the source tracked (e.g. version),
+        // never the password.
+        foreach ($entry as $key => $value) {
+            if ($key === 'password' || array_key_exists($key, $fresh)) {
+                continue;
             }
+            // interface_locale is a DB-backed field handled by userToEntry; if the
+            // user no longer has one, drop it rather than preserving a stale value.
+            if ($key === 'interface_locale') {
+                continue;
+            }
+            $fresh[$key] = $value;
         }
 
-        return $entry;
+        return $fresh;
     }
 
     /**
@@ -353,11 +405,11 @@ class AdminUsers implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
-     * Load an admin user by email; null when none exists.
+     * Load an admin user model by email; null when none exists.
      *
-     * @return array|null Current values keyed by source field (no password), or null.
+     * @return mixed|null Loaded admin user model, or null.
      */
-    private function loadUserByEmail(string $email): ?array
+    private function loadUserByEmail(string $email)
     {
         $user = $this->userFactory->create()->getCollection()
             ->addFieldToFilter('email', $email)
@@ -367,7 +419,7 @@ class AdminUsers implements ComponentInterface, ExportableComponentInterface
             return null;
         }
 
-        return $this->userToEntry($user);
+        return $user;
     }
 
     /**

--- a/Component/CatalogPriceRules.php
+++ b/Component/CatalogPriceRules.php
@@ -141,15 +141,31 @@ class CatalogPriceRules implements ComponentInterface, ExportableComponentInterf
                 continue;
             }
 
-            // Rebuild value fields from the DB, preserving non-value keys
-            // (name, version, and any extra keys already in the entry).
+            // A tracked rule exports EVERYTHING about it: re-read the full field
+            // set from the DB (relations such as website_ids/customer_group_ids
+            // re-resolved by ruleToSource) so admin changes to previously
+            // untracked fields are captured. Null/empty values are skipped to
+            // keep the file clean.
+            $entry = ['name' => $name];
             $current = $this->ruleToSource($model);
             foreach (self::EXPORT_FIELDS as $field) {
-                if (array_key_exists($field, $current)) {
-                    $rule[$field] = $current[$field];
+                $value = $current[$field] ?? null;
+                if ($value === null || $value === '' || $value === []) {
+                    continue;
                 }
+                $entry[$field] = $value;
             }
-            $refreshed[$key] = $rule;
+
+            // Preserve the tracked entry's non-DB structural keys (e.g. version),
+            // i.e. anything that is neither the identity key nor a value field.
+            foreach ($rule as $existingKey => $existingValue) {
+                if ($existingKey === 'name' || in_array($existingKey, self::EXPORT_FIELDS, true)) {
+                    continue;
+                }
+                $entry[$existingKey] = $existingValue;
+            }
+
+            $refreshed[$key] = $entry;
         }
 
         $out['rules'] = $refreshed;

--- a/Component/HyvaPages.php
+++ b/Component/HyvaPages.php
@@ -42,6 +42,22 @@ class HyvaPages implements ComponentInterface, ExportableComponentInterface
     private const HYVA_MODULE = 'Hyva_CmsMagento';
     private const TABLE = 'hyva_commerce_cms_page';
 
+    /**
+     * Value-bearing source keys rebuilt from the DB on refresh (inline content
+     * variants, their `*_source` external-file references, and the liveview flag).
+     * Everything else in a tracked entry is a non-DB structural key (version,
+     * create_version_history, version_name, …) and is preserved verbatim.
+     */
+    private const DB_KEYS = [
+        'content',
+        'content_source',
+        'draft_content',
+        'draft_content_source',
+        'published_content',
+        'published_content_source',
+        'is_liveview_enabled',
+    ];
+
     public function __construct(
         private readonly CmsPageFactory $cmsPageFactory,
         private readonly ResourceConnection $resourceConnection,
@@ -318,10 +334,14 @@ class HyvaPages implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
-     * Refresh each tracked identifier's content/liveview flag from the DB,
-     * preserving any non-value keys (version, create_version_history, …). Tracked
-     * identifiers that no longer resolve to a CMS page (or have no Hyvä row) are
-     * kept untouched. Identifiers not matching the filter are kept untouched.
+     * Refresh each tracked identifier by emitting its FULL current state from the
+     * DB (content + is_liveview_enabled), reusing the same row-to-entry builder as
+     * the full export so an admin change to a previously-untracked field (e.g. the
+     * liveview flag) is captured rather than silently dropped. Non-DB structural
+     * keys (version, create_version_history, version_name, version_emoji) and any
+     * `*_source` external-file references are preserved from the tracked entry.
+     * Tracked identifiers that no longer resolve to a CMS page (or have no Hyvä
+     * row), and identifiers not matching the filter, are kept untouched.
      *
      * @param array $existing
      * @param string|null $filter
@@ -351,44 +371,57 @@ class HyvaPages implements ComponentInterface, ExportableComponentInterface
                 continue;
             }
 
-            $out[$id] = $this->applyRowToEntry($entry, $row);
+            $out[$id] = $this->buildEntryFromRow($entry, $row);
         }
 
         return $out;
     }
 
     /**
-     * Update the value-bearing keys of an existing tracked entry from a DB row,
-     * preserving its content shape (shared `content`/`content_source` vs separate
-     * draft/published variants) and any non-value keys (version, version_name, …).
+     * Build a tracked entry's FULL current state from a Hyvä DB row.
+     *
+     * The DB-backed content and liveview flag are rebuilt from scratch via the same
+     * shaping the full export uses (draft == published collapses to a single inline
+     * `content`, otherwise separate `draft_content`/`published_content`). When the
+     * tracked entry sources its content from external files (`*_source` keys), those
+     * references are preserved and the corresponding inline content key is NOT
+     * emitted (we cannot rewrite the external file from here). Non-DB structural
+     * keys (version, create_version_history, …) are preserved from the entry.
      *
      * @param array<string, mixed> $entry
      * @param array<string, mixed> $row
      * @return array<string, mixed>
      */
-    private function applyRowToEntry(array $entry, array $row): array
+    private function buildEntryFromRow(array $entry, array $row): array
     {
-        $draft = (string) ($row['draft_content'] ?? '');
-        $published = (string) ($row['published_content'] ?? '');
+        $full = $this->shapeRow($row);
 
-        // *_source keys reference external files we cannot rewrite here, so they are
-        // preserved untouched; only inline content keys and the liveview flag are refreshed.
-        if (array_key_exists('content', $entry)) {
-            // Shared inline content maps to both draft and published; prefer published.
-            $entry['content'] = $published;
-        }
-        if (array_key_exists('draft_content', $entry)) {
-            $entry['draft_content'] = $draft;
-        }
-        if (array_key_exists('published_content', $entry)) {
-            $entry['published_content'] = $published;
-        }
-
-        if (array_key_exists('is_liveview_enabled', $entry)) {
-            $entry['is_liveview_enabled'] = (bool) (int) ($row['is_liveview_enabled'] ?? 0);
+        // External-file content references cannot be rewritten here: keep the
+        // `*_source` key and drop the inline content the full shaping would emit.
+        if (array_key_exists('content_source', $entry)) {
+            unset($full['content'], $full['draft_content'], $full['published_content']);
+            $full['content_source'] = $entry['content_source'];
+        } else {
+            if (array_key_exists('draft_content_source', $entry)) {
+                unset($full['content'], $full['draft_content']);
+                $full['draft_content_source'] = $entry['draft_content_source'];
+            }
+            if (array_key_exists('published_content_source', $entry)) {
+                unset($full['content'], $full['published_content']);
+                $full['published_content_source'] = $entry['published_content_source'];
+            }
         }
 
-        return $entry;
+        // Preserve non-DB structural keys (version, create_version_history,
+        // version_name, version_emoji, …) carried by the tracked entry.
+        foreach ($entry as $key => $value) {
+            if (in_array($key, self::DB_KEYS, true)) {
+                continue;
+            }
+            $full[$key] = $value;
+        }
+
+        return $full;
     }
 
     /**
@@ -415,23 +448,36 @@ class HyvaPages implements ComponentInterface, ExportableComponentInterface
 
         $out = [];
         foreach ($connection->fetchAll($select) as $row) {
-            $identifier = (string) $row['identifier'];
-            $draft = (string) ($row['draft_content'] ?? '');
-            $published = (string) ($row['published_content'] ?? '');
-
-            $entry = ['is_liveview_enabled' => (bool) (int) ($row['is_liveview_enabled'] ?? 0)];
-
-            if ($draft === $published) {
-                $entry['content'] = $published;
-            } else {
-                $entry['draft_content'] = $draft;
-                $entry['published_content'] = $published;
-            }
-
-            $out[$identifier] = $entry;
+            $out[(string) $row['identifier']] = $this->shapeRow($row);
         }
 
         return $out;
+    }
+
+    /**
+     * Shape a single Hyvä DB row into a source-format entry: the liveview flag plus
+     * either a shared inline `content` (when draft == published) or separate
+     * `draft_content`/`published_content`. Shared by full export and refresh so both
+     * emit the same full field set for a given row.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function shapeRow(array $row): array
+    {
+        $draft = (string) ($row['draft_content'] ?? '');
+        $published = (string) ($row['published_content'] ?? '');
+
+        $entry = ['is_liveview_enabled' => (bool) (int) ($row['is_liveview_enabled'] ?? 0)];
+
+        if ($draft === $published) {
+            $entry['content'] = $published;
+        } else {
+            $entry['draft_content'] = $draft;
+            $entry['published_content'] = $published;
+        }
+
+        return $entry;
     }
 
     public function getAlias(): string

--- a/Component/OrderStatuses.php
+++ b/Component/OrderStatuses.php
@@ -129,10 +129,12 @@ class OrderStatuses implements ComponentInterface, ExportableComponentInterface
 
     /**
      * Export current order statuses into the source format. Refresh mode rewrites
-     * only the status codes already tracked in the source file (refreshing their
-     * name from the DB and preserving state grouping and non-value keys such as
-     * version); full mode dumps every status grouped by its assigned state,
-     * optionally limited to codes that start with the given filter.
+     * the status codes already tracked in the source file to their full current
+     * state from the DB (refreshing each status's name and re-resolving its state
+     * assignment, regrouping it under the new state when the admin moved it, while
+     * preserving non-value keys such as version); full mode dumps every status
+     * grouped by its assigned state, optionally limited to codes that start with
+     * the given filter.
      */
     public function export(ExportContext $context): array
     {
@@ -176,9 +178,14 @@ class OrderStatuses implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
-     * Walk the tracked source structure and refresh each tracked status's name
-     * from the DB, preserving state grouping and any non-value keys (version).
-     * Tracked statuses whose record no longer exists in the DB are kept untouched.
+     * Refresh each tracked status to its FULL current state from the DB: every
+     * field a status carries in this component's source format — its `name`
+     * (the only value field) and its `state` assignment (the relation grouping
+     * it under a parent state) — is re-resolved live, so an admin moving a status
+     * to another state or relabelling it is captured rather than silently lost.
+     * Non-DB structural keys present on a tracked entry (e.g. version) are
+     * preserved. Tracked statuses whose record no longer exists in the DB, and
+     * any non-value keys on the state set, are kept untouched.
      *
      * @param array $existing
      * @return array
@@ -208,12 +215,79 @@ class OrderStatuses implements ComponentInterface, ExportableComponentInterface
                     continue;
                 }
 
+                // Refresh the only value field; preserve structural keys (version).
                 $statusEntry['name'] = $statusMap[$code]['name'];
                 $out['order_statuses'][$setIndex]['statuses'][$statusIndex] = $statusEntry;
+
+                // Re-resolve the state relation: if the admin reassigned this
+                // status to a different state, move it under that state's set so
+                // the refreshed file reflects the live grouping. Fall back to the
+                // tracked state when the DB row carries no state assignment.
+                $dbState = $statusMap[$code]['state'];
+                $trackedState = isset($statusSet['state']) ? (string) $statusSet['state'] : null;
+                if ($dbState !== null && $dbState !== '' && $dbState !== $trackedState) {
+                    unset($out['order_statuses'][$setIndex]['statuses'][$statusIndex]);
+                    $out = $this->moveStatusToState($out, $dbState, $statusEntry);
+                }
             }
         }
 
+        $out['order_statuses'] = $this->pruneEmptyStatusSets($out['order_statuses']);
+
         return $out;
+    }
+
+    /**
+     * Place a refreshed status entry under the set for $state within the tracked
+     * structure, reusing an existing tracked set for that state when present or
+     * appending a new one otherwise. Returns the mutated order_statuses payload.
+     *
+     * @param array $out
+     * @param string $state
+     * @param array $statusEntry
+     * @return array
+     */
+    private function moveStatusToState(array $out, string $state, array $statusEntry): array
+    {
+        foreach ($out['order_statuses'] as $index => $set) {
+            if (is_array($set) && isset($set['state']) && (string) $set['state'] === $state) {
+                $out['order_statuses'][$index]['statuses'][] = $statusEntry;
+                return $out;
+            }
+        }
+
+        $out['order_statuses'][] = ['state' => $state, 'statuses' => [$statusEntry]];
+
+        return $out;
+    }
+
+    /**
+     * Drop state sets left with no statuses (and re-key the statuses arrays) after
+     * statuses have been moved between states during a refresh, keeping the file
+     * clean. Sets that are not well-formed are left untouched.
+     *
+     * @param array $sets
+     * @return array
+     */
+    private function pruneEmptyStatusSets(array $sets): array
+    {
+        $out = [];
+        foreach ($sets as $set) {
+            if (!is_array($set) || !isset($set['statuses']) || !is_array($set['statuses'])) {
+                $out[] = $set;
+                continue;
+            }
+
+            $statuses = array_values($set['statuses']);
+            if ($statuses === []) {
+                continue;
+            }
+
+            $set['statuses'] = $statuses;
+            $out[] = $set;
+        }
+
+        return array_values($out);
     }
 
     /**

--- a/Component/Websites.php
+++ b/Component/Websites.php
@@ -529,8 +529,11 @@ class Websites implements ComponentInterface, ExportableComponentInterface
 
     /**
      * Walk the tracked source structure and refresh each tracked website/group/
-     * store-view from the DB. Tracked entries whose record no longer exists are
-     * kept untouched. Non-value keys carried in the source are preserved.
+     * store-view from the DB. A tracked entity comes back with its FULL current
+     * field set (every scalar column with a value) — not just the keys the source
+     * file already listed — so admin changes to previously-untracked fields are
+     * captured. Tracked entries whose record no longer exists are kept untouched,
+     * and any non-DB structural keys carried in the source are preserved.
      *
      * @param array $existing
      * @return array
@@ -559,8 +562,9 @@ class Websites implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
-     * Refresh a tracked website entry's scalar fields and its tracked store groups
-     * from the live website model, preserving the entry's existing key set.
+     * Refresh a tracked website entry, emitting every scalar field the live website
+     * model carries (skipping empties), preserving the entry's non-DB structural
+     * keys (e.g. version), and re-resolving the nested store groups from the DB.
      *
      * @param array $entry
      * @param Website $website
@@ -568,35 +572,48 @@ class Websites implements ComponentInterface, ExportableComponentInterface
      */
     private function refreshWebsiteEntry(array $entry, Website $website): array
     {
+        // Exclude internal/auto-increment ids and the redundant code (the YAML key)
+        // so the export stays portable across environments.
+        $refreshed = $this->scalarData($website->getData(), ['store_groups', 'website_id', 'default_group_id', 'code']);
+
+        // Preserve non-DB structural keys the source tracked (e.g. version).
         foreach ($entry as $key => $value) {
-            if ($key === 'store_groups' || is_array($value)) {
+            if ($key === 'store_groups' || array_key_exists($key, $refreshed)) {
                 continue;
             }
-            $current = $website->getData((string) $key);
-            if ($current !== null) {
-                $entry[$key] = $current;
+            if (is_array($value) || $website->getData((string) $key) !== null) {
+                continue;
             }
+            $refreshed[$key] = $value;
         }
 
+        // Re-resolve the nested store groups from the DB, refreshing each tracked
+        // group in place so its key/order is kept and untracked DB fields surface.
         if (isset($entry['store_groups']) && is_array($entry['store_groups'])) {
+            $groups = [];
             foreach ($entry['store_groups'] as $i => $groupEntry) {
                 if (!is_array($groupEntry)) {
+                    $groups[$i] = $groupEntry;
                     continue;
                 }
                 $group = $this->loadGroupForEntry($groupEntry, $website);
                 if ($group === null || !$group->getId()) {
+                    $groups[$i] = $groupEntry;
                     continue;
                 }
-                $entry['store_groups'][$i] = $this->refreshGroupEntry($groupEntry, $group);
+                $groups[$i] = $this->refreshGroupEntry($groupEntry, $group);
             }
+            $refreshed['store_groups'] = $groups;
         }
 
-        return $entry;
+        return $refreshed;
     }
 
     /**
-     * Refresh a tracked store-group entry's scalar fields and its tracked store
-     * views from the live group model, preserving the entry's existing key set.
+     * Refresh a tracked store-group entry, emitting every scalar field the live
+     * group model carries (skipping empties), preserving the entry's non-DB
+     * structural keys, re-resolving the `default_store` relation, and re-resolving
+     * the nested store views from the DB.
      *
      * @param array $entry
      * @param Group $group
@@ -604,42 +621,53 @@ class Websites implements ComponentInterface, ExportableComponentInterface
      */
     private function refreshGroupEntry(array $entry, Group $group): array
     {
+        $refreshed = $this->scalarData($group->getData(), ['store_views', 'default_store', 'website_id']);
+
+        // Preserve non-DB structural keys the source tracked (e.g. version).
         foreach ($entry as $key => $value) {
-            if ($key === 'store_views' || $key === 'default_store' || is_array($value)) {
+            if (in_array($key, ['store_views', 'default_store'], true) || array_key_exists($key, $refreshed)) {
                 continue;
             }
-            $current = $group->getData((string) $key);
-            if ($current !== null) {
-                $entry[$key] = $current;
+            if (is_array($value) || $group->getData((string) $key) !== null) {
+                continue;
             }
+            $refreshed[$key] = $value;
         }
 
-        if (array_key_exists('default_store', $entry)) {
-            $defaultStore = $group->getDefaultStore();
-            if ($defaultStore && $defaultStore->getId()) {
-                $entry['default_store'] = (string) $defaultStore->getCode();
-            }
+        // Re-resolve the default store relation from the DB.
+        $defaultStore = $group->getDefaultStore();
+        if ($defaultStore && $defaultStore->getId()) {
+            $refreshed['default_store'] = (string) $defaultStore->getCode();
+        } elseif (array_key_exists('default_store', $entry)) {
+            $refreshed['default_store'] = $entry['default_store'];
         }
 
+        // Re-resolve the nested store views from the DB.
         if (isset($entry['store_views']) && is_array($entry['store_views'])) {
+            $views = [];
             foreach ($entry['store_views'] as $viewCode => $viewEntry) {
                 if (!is_array($viewEntry)) {
+                    $views[$viewCode] = $viewEntry;
                     continue;
                 }
                 $storeView = $this->storeFactory->create();
                 $storeView->load((string) $viewCode, 'code');
                 if (!$storeView->getId()) {
+                    $views[$viewCode] = $viewEntry;
                     continue;
                 }
-                $entry['store_views'][$viewCode] = $this->refreshStoreViewEntry($viewEntry, $storeView);
+                $views[$viewCode] = $this->refreshStoreViewEntry($viewEntry, $storeView);
             }
+            $refreshed['store_views'] = $views;
         }
 
-        return $entry;
+        return $refreshed;
     }
 
     /**
-     * Refresh a tracked store-view entry's scalar fields from the live store model.
+     * Refresh a tracked store-view entry, emitting every scalar field the live
+     * store model carries (skipping empties), preserving the entry's non-DB
+     * structural keys.
      *
      * @param array $entry
      * @param Store $storeView
@@ -647,17 +675,45 @@ class Websites implements ComponentInterface, ExportableComponentInterface
      */
     private function refreshStoreViewEntry(array $entry, Store $storeView): array
     {
+        $refreshed = $this->scalarData($storeView->getData(), ['store_id', 'website_id', 'group_id', 'code']);
+
+        // Preserve non-DB structural keys the source tracked (e.g. version).
         foreach ($entry as $key => $value) {
-            if (is_array($value)) {
+            if (array_key_exists($key, $refreshed)) {
                 continue;
             }
-            $current = $storeView->getData((string) $key);
-            if ($current !== null) {
-                $entry[$key] = $current;
+            if (is_array($value) || $storeView->getData((string) $key) !== null) {
+                continue;
             }
+            $refreshed[$key] = $value;
         }
 
-        return $entry;
+        return $refreshed;
+    }
+
+    /**
+     * Reduce a model's raw data to its scalar columns that carry a value, keeping
+     * files clean: array values (sub-resources), null and empty-string values, and
+     * any explicitly excluded keys (relations rebuilt separately) are dropped.
+     *
+     * @param array $data
+     * @param string[] $exclude
+     * @return array
+     */
+    private function scalarData(array $data, array $exclude = []): array
+    {
+        $out = [];
+        foreach ($data as $key => $value) {
+            if (in_array((string) $key, $exclude, true) || is_array($value)) {
+                continue;
+            }
+            if ($value === null || $value === '') {
+                continue;
+            }
+            $out[(string) $key] = $value;
+        }
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
Extends "tracked entity = export everything about it" (done for pages/blocks in #36) across the other multi-field components, so an admin change to a previously-untracked field/relation isn't lost on refresh.

> Stacked on #36 (base `v2-sync-source-writeback`); retarget to `magebit` once #36 merges.

Done via a parallel audit (one agent per component): 5 needed the change, 8 were already exporting the full entity.

## Changed — refresh now emits the full current entity, not just tracked keys
- **Websites** — all meaningful website/group/store-view fields, re-resolving nested groups/views + `default_store` from the DB. **Internal ids excluded** (`website_id`, `default_group_id`, `store_id`, `group_id`, redundant `code`) so the export stays portable across environments.
- **AdminUsers** — full user fields + re-resolved role; **password is never exported** (verified).
- **OrderStatuses**, **CatalogPriceRules** (curated field set — no `rule_id`), **HyvaPages** (keeps the `Hyva_CmsMagento` module guard).

## Already full (no change)
Widgets, CustomerGroups, AdminRoles, ApiIntegrations, ReviewRating, InventorySources, HyvaBlocks, ShippingTableRates.

## Verification (2.4.7-p3 / PHP 8.3)
- `di:compile` clean; `configurator:list` = 30; conformance **PASS** (forward run intact).
- A website tracked with only `name` + `version` came back with `sort_order` + `is_default` and **no internal ids**.
- AdminUsers `--all` export contains no password.

## Note
One quality fix beyond the agents' output: the Websites agent initially dumped raw `getData()` (leaking `website_id`/`default_group_id`/etc.); corrected to exclude internal ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)