### PR TITLE
v2: sync-from-db --all covers all components + writes source: files for CMS

### DIFF
--- a/Component/Blocks.php
+++ b/Component/Blocks.php
@@ -36,6 +36,9 @@ class Blocks implements ComponentInterface, ExportableComponentInterface
     private const ALIAS = 'blocks';
     private const DESCRIPTION = 'Component to create/maintain blocks.';
 
+    /** Where a full export writes block content files referenced via `source:`. */
+    private const EXPORT_CONTENT_DIR = 'app/etc/configurator/Blocks/content';
+
     protected $viewModelRegistry = null;
 
     public function __construct(
@@ -362,7 +365,7 @@ class Blocks implements ComponentInterface, ExportableComponentInterface
     public function export(ExportContext $context): array
     {
         return $context->isFullExport()
-            ? $this->exportAll($context->getFilter())
+            ? $this->exportAll($context->getFilter(), $context->isDryRun())
             : $this->refreshTracked($context->getExistingData(), $context->isDryRun());
     }
 
@@ -480,7 +483,7 @@ class Blocks implements ComponentInterface, ExportableComponentInterface
      * @param string|null $filter
      * @return array
      */
-    private function exportAll(?string $filter): array
+    private function exportAll(?string $filter, bool $dryRun): array
     {
         $collection = $this->blockFactory->create()->getCollection();
         if ($filter !== null && $filter !== '') {
@@ -490,9 +493,15 @@ class Blocks implements ComponentInterface, ExportableComponentInterface
         $out = [];
         foreach ($collection as $block) {
             $identifier = (string) $block->getIdentifier();
+
+            // Content is written to an external .html file and referenced via
+            // `source:`, never inlined into the YAML.
+            $source = self::EXPORT_CONTENT_DIR . '/' . $identifier . '.html';
+            $this->writeSourceContent($source, (string) $block->getContent(), $dryRun);
+
             $definition = [
                 'title' => $block->getTitle(),
-                'content' => $block->getContent(),
+                'source' => $source,
                 'is_active' => (int) $block->getIsActive(),
             ];
 

--- a/Component/Pages.php
+++ b/Component/Pages.php
@@ -45,6 +45,9 @@ class Pages implements ComponentInterface, ExportableComponentInterface
     private const ALIAS = 'pages';
     private const DESCRIPTION = 'Component to create/maintain pages.';
 
+    /** Where a full export writes page content files referenced via `source:`. */
+    private const EXPORT_CONTENT_DIR = 'app/etc/configurator/Pages/content';
+
     /**
      * CMS page fields written back to source on export, in source-file order.
      * `content` is the rendered output of a `source` template on import, so when an
@@ -433,7 +436,7 @@ class Pages implements ComponentInterface, ExportableComponentInterface
     public function export(ExportContext $context): array
     {
         return $context->isFullExport()
-            ? $this->exportAll($context->getFilter())
+            ? $this->exportAll($context->getFilter(), $context->isDryRun())
             : $this->refreshTracked($context->getExistingData(), $context->getFilter(), $context->isDryRun());
     }
 
@@ -583,7 +586,7 @@ class Pages implements ComponentInterface, ExportableComponentInterface
      * @param string|null $filter
      * @return array
      */
-    private function exportAll(?string $filter): array
+    private function exportAll(?string $filter, bool $dryRun): array
     {
         $connection = $this->resourceConnection->getConnection();
         $cmsPageTable = $connection->getTableName('cms_page');
@@ -610,8 +613,17 @@ class Pages implements ComponentInterface, ExportableComponentInterface
 
             $entry = [];
             foreach (self::EXPORT_FIELDS as $field) {
+                // Content is written to an external .html file and referenced via
+                // `source:`, never inlined into the YAML.
+                if ($field === 'content') {
+                    continue;
+                }
                 $entry[$field] = $page->getData($field);
             }
+
+            $source = self::EXPORT_CONTENT_DIR . '/' . $identifier . '.html';
+            $this->writeSourceContent($source, (string) $page->getData('content'), $dryRun);
+            $entry['source'] = $source;
 
             $stores = $this->resolveStoreCodes($pageId);
             if ($stores !== []) {

--- a/Model/Export/Exporter.php
+++ b/Model/Export/Exporter.php
@@ -29,6 +29,9 @@ class Exporter
     private const YAML_INLINE_DEPTH = 6;
     private const YAML_INDENT = 2;
 
+    /** Aliases whose source files are CSV, used when deriving a default target path. */
+    private const CSV_ALIASES = ['rewrites', 'taxrates', 'taxrules', 'customers', 'products', 'tiered_prices'];
+
     public function __construct(
         private readonly ComponentListInterface $componentList,
         private readonly LoggerInterface $log
@@ -42,7 +45,17 @@ class Exporter
     public function export(array $aliases, bool $full, ?string $filter, ?string $output, bool $dryRun): array
     {
         $master = $this->readMaster();
-        $targets = $aliases !== [] ? $aliases : array_keys($master);
+
+        if ($aliases !== []) {
+            $targets = $aliases;
+        } elseif ($full) {
+            // Full export with no explicit components: every exportable component,
+            // independent of master.yaml wiring (the point of --all is "dump the DB").
+            $targets = array_keys($this->exportableComponents());
+        } else {
+            // Refresh with no explicit components: only what master.yaml already tracks.
+            $targets = array_keys($master);
+        }
 
         $written = [];
         $skipped = [];
@@ -56,7 +69,12 @@ class Exporter
                 continue;
             }
 
-            if (!isset($master[$alias]['sources']) || $master[$alias]['sources'] === []) {
+            $sources = isset($master[$alias]['sources']) ? (array) $master[$alias]['sources'] : [];
+
+            // Refresh needs existing source files to rewrite; a full export can always
+            // produce output (an explicit --output, the first master source, or a
+            // conventional default path), so it is never skipped for lack of sources.
+            if (!$full && $sources === []) {
                 $this->log->logError(sprintf("No sources defined for '%s' in master.yaml; skipping.", $alias));
                 $skipped[] = $alias;
                 continue;
@@ -64,7 +82,7 @@ class Exporter
 
             // Resilience: a single component failing must not abort the whole run.
             try {
-                foreach ($this->exportComponent($component, (array) $master[$alias]['sources'], $full, $filter, $output, $dryRun) as $path) {
+                foreach ($this->exportComponent($component, $sources, $alias, $full, $filter, $output, $dryRun) as $path) {
                     $written[] = $path;
                 }
             } catch (\Throwable $t) {
@@ -92,14 +110,17 @@ class Exporter
     private function exportComponent(
         ExportableComponentInterface $component,
         array $sources,
+        string $alias,
         bool $full,
         ?string $filter,
         ?string $output,
         bool $dryRun
     ): array {
         if ($full) {
-            // One pass: write the full export to an explicit target or the first source.
-            $target = $output ?? $this->resolvePath((string) $sources[0]);
+            // One pass to: an explicit --output, else the first master source, else a
+            // conventional default path so an unwired component still exports.
+            $target = $output
+                ?? (isset($sources[0]) ? $this->resolvePath((string) $sources[0]) : $this->defaultTarget($alias));
             $data = $component->export(new ExportContext([], true, $filter, $dryRun));
             $this->writeFile($target, $data, $dryRun);
             return [$target];
@@ -138,6 +159,31 @@ class Exporter
     private function resolvePath(string $source): string
     {
         return BP . '/' . ltrim($source, '/');
+    }
+
+    /**
+     * Exportable components keyed by alias.
+     *
+     * @return array<string, ExportableComponentInterface>
+     */
+    private function exportableComponents(): array
+    {
+        return array_filter(
+            $this->componentList->getAllComponents(),
+            static fn ($component) => $component instanceof ExportableComponentInterface
+        );
+    }
+
+    /**
+     * Conventional source path for a full export of a component that has no source
+     * wired in master.yaml: app/etc/configurator/<StudlyFolder>/<alias>.<ext>.
+     */
+    private function defaultTarget(string $alias): string
+    {
+        $folder = str_replace(' ', '', ucwords(str_replace('_', ' ', $alias)));
+        $ext = in_array($alias, self::CSV_ALIASES, true) ? 'csv' : 'yaml';
+
+        return BP . '/app/etc/configurator/' . $folder . '/' . $alias . '.' . $ext;
     }
 
     /**

--- a/Test/Unit/Component/BlocksTest.php
+++ b/Test/Unit/Component/BlocksTest.php
@@ -29,6 +29,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
+// The component references the global BP base-dir constant when writing `source:`
+// content files; define a stub so path resolution does not fatal under unit tests.
+if (!defined('BP')) {
+    define('BP', sys_get_temp_dir());
+}
+
 class BlocksTest extends TestCase
 {
     private BlockInterfaceFactory&MockObject $blockFactory;
@@ -219,7 +225,7 @@ class BlocksTest extends TestCase
         $this->assertSame(0, $result->getSkipped());
     }
 
-    public function testExportAllDumpsEveryBlockInline(): void
+    public function testExportAllWritesContentToSourceFile(): void
     {
         $block = $this->getMockBuilder(Block::class)
             ->disableOriginalConstructor()
@@ -235,14 +241,17 @@ class BlocksTest extends TestCase
         $collection = $this->givenIterableCollection([$block]);
         $this->blockFactory->method('create')->willReturn($this->givenCollectionSource($collection));
 
-        $out = $this->component->export(new ExportContext([], true));
+        // Full export + dry-run: content is referenced via `source:` (written to an
+        // external .html file), never inlined; dry-run keeps the filesystem untouched.
+        $out = $this->component->export(new ExportContext([], true, null, true));
 
         $this->assertArrayHasKey('footer-links', $out);
         $this->assertSame([
             'title' => 'Footer Links',
-            'content' => '<p>links</p>',
+            'source' => 'app/etc/configurator/Blocks/content/footer-links.html',
             'is_active' => 1,
         ], $out['footer-links']['block'][0]);
+        $this->assertArrayNotHasKey('content', $out['footer-links']['block'][0]);
         $this->assertArrayNotHasKey('stores', $out['footer-links']['block'][0]);
     }
 

--- a/Test/Unit/Component/PagesTest.php
+++ b/Test/Unit/Component/PagesTest.php
@@ -292,13 +292,16 @@ class PagesTest extends TestCase
         });
         $this->pageRepository->method('getById')->with(42)->willReturn($page);
 
-        $out = $this->component->export(new ExportContext([], true));
+        // Full export + dry-run: content goes to an external `source:` .html file
+        // (not inlined); dry-run keeps the filesystem untouched.
+        $out = $this->component->export(new ExportContext([], true, null, true));
 
         $this->assertArrayHasKey('about-us', $out);
         $entry = $out['about-us']['page'][0];
         $this->assertSame('About Us', $entry['title']);
         $this->assertSame('Welcome', $entry['content_heading']);
-        $this->assertSame('<p>Hi</p>', $entry['content']);
+        $this->assertSame('app/etc/configurator/Pages/content/about-us.html', $entry['source']);
+        $this->assertArrayNotHasKey('content', $entry);
         $this->assertSame('1column', $entry['page_layout']);
         $this->assertArrayNotHasKey('stores', $entry);
     }

--- a/Test/Unit/Model/Export/ExporterTest.php
+++ b/Test/Unit/Model/Export/ExporterTest.php
@@ -182,45 +182,88 @@ class ExporterTest extends TestCase
         $this->assertSame([], $result['written']);
     }
 
-    public function testComponentWithoutSourcesIsSkipped(): void
+    public function testRefreshWithoutSourcesIsSkipped(): void
     {
-        // Listed in master.yaml but no sources defined -> skipped, error logged.
+        // Listed in master.yaml but no sources defined -> refresh has nothing to
+        // rewrite -> skipped, error logged. (A full export, by contrast, falls back
+        // to a default target; see the next test.)
         $this->givenMaster(['customergroups' => ['sources' => []]]);
         $component = $this->givenExportableComponent([]);
         $component->expects($this->never())->method('export');
 
         $this->log->expects($this->atLeastOnce())->method('logError');
 
-        $result = $this->exporter->export(['customergroups'], true, null, null, false);
+        $result = $this->exporter->export(['customergroups'], false, null, null, false);
 
         $this->assertSame(['customergroups'], $result['skipped']);
         $this->assertSame([], $result['written']);
     }
 
-    public function testEmptyAliasesExportsEveryComponentInMaster(): void
+    public function testFullExportFallsBackToDefaultTargetWhenUnwired(): void
+    {
+        // A component not wired in master.yaml still fully exports, to the
+        // conventional app/etc/configurator/<Folder>/<alias>.yaml path.
+        $this->givenMaster([]);
+        $component = $this->givenExportableComponent(['blocks' => []]);
+        $component->method('export')->willReturn(['blocks' => []]);
+
+        $expected = $this->trackPath('app/etc/configurator/Blocks/blocks.yaml');
+        $result = $this->exporter->export(['blocks'], true, null, null, false);
+
+        $this->assertSame([$expected], $result['written']);
+        $this->assertFileExists($expected);
+    }
+
+    public function testRefreshEmptyAliasesUsesMasterKeys(): void
     {
         $this->givenMaster([
             'customergroups' => ['sources' => ['app/etc/configurator/customergroups.yaml']],
             'plain' => ['sources' => ['app/etc/configurator/plain.yaml']],
         ]);
 
-        // Build the exportable component directly (not via the helper) so we don't
-        // register a blanket getComponent() stub that would shadow the map below.
         $exportable = $this->createMock(ExportableComponentStub::class);
         $exportable->method('export')->willReturn(['customergroups' => []]);
         $plain = $this->createMock(ComponentInterface::class);
 
-        // Aliases come from master.yaml keys when none are supplied.
+        // Refresh with no explicit aliases targets the master.yaml keys.
         $this->componentList->method('getComponent')->willReturnMap([
             ['customergroups', $exportable],
             ['plain', $plain],
         ]);
 
         $cgPath = $this->trackPath('app/etc/configurator/customergroups.yaml');
-        $result = $this->exporter->export([], true, null, null, false);
+        file_put_contents($cgPath, Yaml::dump(['customergroups' => []]));
+        $result = $this->exporter->export([], false, null, null, false);
 
         $this->assertSame([$cgPath], $result['written']);
         $this->assertSame(['plain'], $result['skipped']);
+    }
+
+    public function testFullEmptyAliasesExportsEveryExportableComponent(): void
+    {
+        // --all with no --component: every exportable component, independent of
+        // master.yaml wiring. 'blocks' has no master entry, so it lands on its
+        // default target; the non-exportable component is skipped.
+        $this->givenMaster([]);
+
+        $blocks = $this->createMock(ExportableComponentStub::class);
+        $blocks->method('export')->willReturn(['b' => []]);
+        $plain = $this->createMock(ComponentInterface::class);
+
+        $this->componentList->method('getAllComponents')->willReturn([
+            'blocks' => $blocks,
+            'plain' => $plain,
+        ]);
+        $this->componentList->method('getComponent')->willReturnMap([
+            ['blocks', $blocks],
+            ['plain', $plain],
+        ]);
+
+        $blocksPath = $this->trackPath('app/etc/configurator/Blocks/blocks.yaml');
+        $result = $this->exporter->export([], true, null, null, false);
+
+        // Only exportable components are enumerated, so 'plain' isn't even a target.
+        $this->assertSame([$blocksPath], $result['written']);
     }
 
     public function testComponentExportFailureIsIsolatedAndRecorded(): void

--- a/docs/schema/blocks.md
+++ b/docs/schema/blocks.md
@@ -66,6 +66,11 @@ can call escaping helpers and Hyvä view models. A plain HTML file such as
 - **Versioning.** When `version` is set it is compared against the stored version
   (keyed by `blocks_<identifier>` plus the store codes). Only a higher version is
   treated as a new version; after a successful apply the new version is recorded.
+- **Sync from DB.** `configurator:sync-from-db --component=blocks --all` exports every
+  block: each block's content is written to an external file under
+  `app/etc/configurator/Blocks/content/<identifier>.html` and the YAML entry references
+  it via `source:` (never inlined as `content:`). When the component isn't wired in
+  `master.yaml`, the export still runs and defaults to `app/etc/configurator/Blocks/blocks.yaml`.
 - **Removal.** `remove: true` on a definition deletes the matching block via the
   block repository, in either mode, and records it as *removed* in the run summary.
   A block that does not exist is recorded as *skipped* (no error), so the entry is

--- a/docs/schema/pages.md
+++ b/docs/schema/pages.md
@@ -73,6 +73,11 @@ becomes the page content.
   pages are created in both modes.
 - **Versioning.** Identical to blocks: only a higher `version` re-applies the page;
   the new version is recorded after a successful apply.
+- **Sync from DB.** `configurator:sync-from-db --component=pages --all` exports every
+  page: each page's content is written to an external file under
+  `app/etc/configurator/Pages/content/<identifier>.html` and the YAML entry references
+  it via `source:` (never inlined as `content:`). When the component isn't wired in
+  `master.yaml`, the export still runs and defaults to `app/etc/configurator/Pages/pages.yaml`.
 - **Removal.** `remove: true` on a definition deletes the matching page via the
   page repository, in either mode, and records it as *removed* in the run summary.
   A page that does not exist is recorded as *skipped* (no error). Dry-run logs


### PR DESCRIPTION
Two fixes to `configurator:sync-from-db --all`, both reported from a real Venta export where `--all` produced no CMS blocks and inlined `content:`.

## 1. `--all` now exports every exportable component, regardless of `master.yaml`
Previously, with no `--component`:
- it only iterated components **wired in `master.yaml`** — so blocks/pages absent from a project's master were silently never exported;
- and an explicitly-targeted component with no `sources` entry was skipped.

Now a full export enumerates **all exportable components** (`getAllComponents()`) and resolves the output to `--output` → first master source → a conventional **default target** `app/etc/configurator/<Folder>/<alias>.yaml`. Refresh mode is unchanged (still needs an existing source file to rewrite in place).

## 2. Full export of `blocks`/`pages` writes `source:` files, not inline `content:`
`exportAll` now writes each entity's content to an external file —
`app/etc/configurator/{Blocks,Pages}/content/<identifier>.html` — and the YAML entry references it via `source:`. No `content:` is inlined. Honors `--dry-run`.

### Result (real Venta run of `sync-from-db --component=blocks --all`)
```yaml
contact-us-info:
  block:
    - title: 'Contact us info'
      source: app/etc/configurator/Blocks/content/contact-us-info.html
      is_active: 1
```
33 blocks → `Blocks/blocks.yaml` + one `.html` per block under `Blocks/content/`.

## Tests
Updated the Blocks/Pages full-export tests (now assert `source:`) and restructured `ExporterTest` for the new default-target + all-exportable enumeration. **447 tests, 1419 assertions** green under strict flags on PHPUnit 9.6 in a real Magento install. Schema docs for pages/blocks updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
