### PR TITLE
v2: fix post-release component gaps (Categories, Widgets, TaxRates, Pages, TaxRules, Attributes)

### DIFF
--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -74,6 +74,24 @@ class Attributes implements ComponentInterface, ExportableComponentInterface
     ];
 
     /**
+     * Keys EavSetup::addAttribute() accepts but that are not stored on the row
+     * returned by getAttribute() — they live in eav_entity_attribute (the
+     * attribute-set/group pivot) or are scope-specific, and which ones are absent
+     * depends on the entity type. They cannot be diffed against the loaded
+     * attribute, so when absent they must be skipped silently rather than reported
+     * as "does not exist or is not mapped". When the entity type does expose one of
+     * them on the row, it is still diffed normally.
+     *
+     * @var array
+     */
+    protected $addAttributeOnly = [
+        'visible',
+        'sort_order',
+        'group',
+        'position',
+    ];
+
+    /**
      * @var string
      */
     protected $entityTypeId = Product::ENTITY;
@@ -296,11 +314,15 @@ class Attributes implements ComponentInterface, ExportableComponentInterface
                 continue;
             }
             if (!array_key_exists($name, $attributeArray)) {
-                $this->log->logError(sprintf(
-                    'Attribute %s type %s does not exist or is not mapped',
-                    $attributeCode,
-                    $name
-                ), $nest);
+                // Known addAttribute-only keys aren't on the loaded row for this
+                // entity type; their absence is expected, not a misconfiguration.
+                if (!in_array($name, $this->addAttributeOnly, true)) {
+                    $this->log->logError(sprintf(
+                        'Attribute %s type %s does not exist or is not mapped',
+                        $attributeCode,
+                        $name
+                    ), $nest);
+                }
                 continue;
             }
 

--- a/Component/Categories.php
+++ b/Component/Categories.php
@@ -168,6 +168,7 @@ class Categories implements ComponentInterface, ExportableComponentInterface
              * @var $category Category
              */
             $category = $this->category->create()->getCollection()
+                ->addAttributeToSelect('*')
                 ->addFieldToFilter('name', $categoryValues['name'])
                 ->addFieldToFilter('parent_id', $parentCategory->getId())
                 ->setPageSize(1)
@@ -184,17 +185,25 @@ class Categories implements ComponentInterface, ExportableComponentInterface
                 continue;
             }
 
+            // Per-entity diff: an existing category whose tracked fields already match
+            // the DB is left untouched. This avoids the no-op re-save that would
+            // otherwise regenerate URL rewrites and throw UrlAlreadyExistsException.
+            $unchanged = $exists && $this->isCategoryUnchanged($category, $categoryValues);
+
             $version = $categoryValues['version'] ?? null;
             $request = new ReconciliationRequest(
                 self::ALIAS,
                 $parentCategory->getId() . '_' . $categoryValues['name'],
                 $mode,
                 $exists,
-                $version ? (int) $version : null
+                $version ? (int) $version : null,
+                $exists ? $unchanged : null
             );
 
             if ($this->gate->decide($request)->isSkip()) {
-                $this->log->logComment(sprintf("Skip category '%s' modification in create mode: ", $categoryValues['name']));
+                $this->log->logComment(
+                    sprintf("Skip category '%s' modification (unchanged or create mode)", $categoryValues['name'])
+                );
                 $result->recordSkipped();
                 continue;
             }
@@ -278,6 +287,59 @@ class Categories implements ComponentInterface, ExportableComponentInterface
                 $this->createOrUpdateCategory($category, $categoryValues['categories'], $mode, $dryRun, $result);
             }
         }
+    }
+
+    /**
+     * Compare the source-tracked fields against the loaded category to decide
+     * whether anything would actually change. Mirrors the value resolution done
+     * by createOrUpdateCategory() but performs no side effects (no image copy,
+     * no save), so an unchanged category can be skipped entirely.
+     *
+     * Control keys (version, remove, categories) are ignored. When `is_active`
+     * is omitted from the source the writer defaults it to active, so the same
+     * default is asserted here.
+     *
+     * @param Category $category
+     * @param array $categoryValues
+     * @return bool
+     */
+    private function isCategoryUnchanged(Category $category, array $categoryValues): bool
+    {
+        foreach ($categoryValues as $attribute => $value) {
+            switch (true) {
+                case $attribute === 'version':
+                case $attribute === 'remove':
+                case $attribute === 'category':
+                case $attribute === 'categories':
+                    break;
+                case $attribute === 'image':
+                    // phpcs:ignore Magento2.Functions.DiscouragedFunction
+                    if (basename((string) $value) !== (string) $category->getData('image')) {
+                        return false;
+                    }
+                    break;
+                case $attribute === 'landing_page':
+                    $block = $this->blockFactory->create()->setStoreId($category->getStoreId());
+                    $this->blockResource->load($block, $value, 'identifier');
+                    if ($block->getIdentifier()
+                        && (string) $block->getId() !== (string) $category->getData('landing_page')
+                    ) {
+                        return false;
+                    }
+                    break;
+                default:
+                    if ((string) $category->getData($attribute) !== (string) $value) {
+                        return false;
+                    }
+            }
+        }
+
+        // The writer activates a category by default when `is_active` is unset.
+        if (!isset($categoryValues['is_active']) && (string) $category->getData('is_active') !== '1') {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/Component/Pages.php
+++ b/Component/Pages.php
@@ -281,18 +281,30 @@ class Pages implements ComponentInterface, ExportableComponentInterface
                     }
                 }
 
-                // Process stores
-                $page->setStores([0]);
+                // Resolve the desired store assignment: default scope ([0]) unless the
+                // source pins the page to specific store views.
+                $desiredStores = [0];
                 if (isset($pageData['stores'])) {
-                    $page->unsetData('store_id');
-                    $page->unsetData('store_data');
-
-                    $stores = [];
+                    $desiredStores = [];
                     foreach ($pageData['stores'] as $code) {
-                        $stores[] = $store = $this->storeRepository->get($code)->getId();
+                        $desiredStores[] = (int) $this->storeRepository->get($code)->getId();
                     }
+                }
 
-                    $page->setStores($stores);
+                // Only (re)assign stores when the assignment actually differs from what
+                // is stored. Setting it unconditionally marked the model dirty and
+                // produced a phantom "Save page" on every run for unchanged pages.
+                $currentStores = array_map('intval', (array) $page->getData('store_id'));
+                sort($currentStores);
+                $sortedDesired = $desiredStores;
+                sort($sortedDesired);
+
+                if ($isNew || $currentStores !== $sortedDesired) {
+                    if (isset($pageData['stores'])) {
+                        $page->unsetData('store_id');
+                        $page->unsetData('store_data');
+                    }
+                    $page->setStores($desiredStores);
                 }
 
                 //we only need to save if the model has changed

--- a/Component/TaxRates.php
+++ b/Component/TaxRates.php
@@ -26,6 +26,25 @@ class TaxRates implements ComponentInterface, ExportableComponentInterface
     private const ALIAS = 'taxrates';
     private const DESCRIPTION = 'Component to create Tax Rates';
 
+    /**
+     * The header Magento's CsvImportHandler documents/expects, in the exact
+     * positional order getSortedData() emits each data row. The importer keys
+     * rows by position (not header name), so emitting this canonical header keeps
+     * the file's header consistent with its data and matches what a stricter
+     * importer / admin re-export round-trip expects, instead of the machine-key
+     * header carried in from the source file.
+     */
+    private const IMPORT_HEADER = [
+        'Code',
+        'Country',
+        'State',
+        'Zip/Post Code',
+        'Rate',
+        'Zip/Post is Range',
+        'Range From',
+        'Range To',
+    ];
+
     public function __construct(
         private readonly CsvImportHandler $csvImportHandler,
         private readonly LoggerInterface $log,
@@ -99,8 +118,10 @@ class TaxRates implements ComponentInterface, ExportableComponentInterface
 
         foreach ($data as $index => $rate) {
             if ($index === 0) {
-                $sortedData[] = $rate;
-                continue; // Skip the header row
+                // Emit Magento's canonical header rather than the source machine-key
+                // header, so the header matches the re-ordered data columns below.
+                $sortedData[] = self::IMPORT_HEADER;
+                continue;
             }
 
             $relativeData = array_combine($data[0], $rate);

--- a/Component/TaxRules.php
+++ b/Component/TaxRules.php
@@ -251,12 +251,24 @@ class TaxRules implements ComponentInterface, ExportableComponentInterface
         $existing = $rule->getCollection()->addFieldToFilter('code', $ruleData['code'])->getFirstItem();
         $exists = (bool) $existing->getId();
 
-        $request = new ReconciliationRequest(self::ALIAS, (string) $ruleData['code'], $context->getMode(), $exists);
+        // Per-entity diff: an existing rule whose rate/class ids and scalar fields
+        // already match the source is left untouched, so maintain mode no longer
+        // re-imports (re-saves) every rule on every run.
+        $unchanged = $exists && $this->isRuleUnchanged((int) $existing->getId(), $ruleData);
+
+        $request = new ReconciliationRequest(
+            self::ALIAS,
+            (string) $ruleData['code'],
+            $context->getMode(),
+            $exists,
+            null,
+            $exists ? $unchanged : null
+        );
 
         $outcome = $this->gate->decide($request);
         if ($outcome->isSkip()) {
             $this->log->logComment(
-                sprintf('Tax Rule "%s" exists, skipped (create mode).', $ruleData['code'])
+                sprintf('Tax Rule "%s" skipped (unchanged or create mode).', $ruleData['code'])
             );
             $result->recordSkipped();
 
@@ -286,6 +298,56 @@ class TaxRules implements ComponentInterface, ExportableComponentInterface
             sprintf('Tax Rule "%s" %s.', $ruleData['code'], $outcome->value)
         );
         $outcome->record($result);
+    }
+
+    /**
+     * Compare a fully-loaded tax rule against the formatted source data to decide
+     * whether a save would change anything. The collection item used for the
+     * existence check does not carry the rate/class id associations, so the rule
+     * is loaded in full here. Any failure to load is treated as "changed" so the
+     * save still runs.
+     *
+     * @param int $ruleId
+     * @param array $ruleData formatted source data (ids already resolved)
+     * @return bool
+     */
+    private function isRuleUnchanged(int $ruleId, array $ruleData): bool
+    {
+        $rule = $this->ruleFactory->create();
+        $this->taxRuleResource->load($rule, $ruleId);
+        if (!$rule->getId()) {
+            return false;
+        }
+
+        if ((int) $rule->getPriority() !== (int) $ruleData['priority']
+            || (int) $rule->getPosition() !== (int) $ruleData['position']
+            || (int) $rule->getCalculateSubtotal() !== (int) $ruleData['calculate_subtotal']
+        ) {
+            return false;
+        }
+
+        return $this->sameIdSet($rule->getTaxRateIds(), $ruleData['tax_rate_ids'])
+            && $this->sameIdSet($rule->getCustomerTaxClassIds(), $ruleData['customer_tax_class_ids'])
+            && $this->sameIdSet($rule->getProductTaxClassIds(), $ruleData['product_tax_class_ids']);
+    }
+
+    /**
+     * Order-insensitive comparison of two id lists, normalised to sorted ints.
+     *
+     * @param mixed $a
+     * @param mixed $b
+     * @return bool
+     */
+    private function sameIdSet(mixed $a, mixed $b): bool
+    {
+        $normalise = static function (mixed $ids): array {
+            $ids = array_map('intval', is_array($ids) ? $ids : []);
+            sort($ids);
+
+            return $ids;
+        };
+
+        return $normalise($a) === $normalise($b);
     }
 
     /**

--- a/Component/Widgets.php
+++ b/Component/Widgets.php
@@ -128,6 +128,13 @@ class Widgets implements ComponentInterface, ExportableComponentInterface
                 return;
             }
 
+            if (!$isNew) {
+                // The collection item carries only the widget_instance columns; load the
+                // full instance so page_groups (stored in a separate table) are present
+                // for the diff below and are not dropped when the widget is saved.
+                $this->widgetResource->load($widget, (int) $widget->getId());
+            }
+
             foreach ($widgetData as $key => $value) {
                 // Skip the control key; it is not a widget field.
                 if ($key == "remove") {
@@ -152,7 +159,10 @@ class Widgets implements ComponentInterface, ExportableComponentInterface
                 }
 
                 if ($key == "page_groups" && is_array($value)) {
-                    $value = $this->buildPageGroups($value);
+                    if ($this->savePageGroups($widget, $value)) {
+                        $canSave = true;
+                    }
+                    continue;
                 }
 
                 if ($widget->getData($key) == $value) {
@@ -478,6 +488,70 @@ class Widgets implements ComponentInterface, ExportableComponentInterface
     }
 
     /**
+     * Reconcile a widget's page_groups against the source list. The built input
+     * form is always carried onto the model (so a save triggered by another field
+     * change does not drop the page_groups), but a change is only reported when the
+     * stored placement actually differs from the source.
+     *
+     * The comparison is done in the simplified source shape because the stored
+     * widget_instance_page rows use different column names (block_reference,
+     * page_for, page_template) and a synthetic row id, so the previous raw
+     * comparison against the built input form never matched and forced a re-save
+     * on every run.
+     *
+     * @param Instance $widget the (hydrated) widget instance
+     * @param array $sourceGroups the source `page_groups` list
+     * @return bool true when the placement changed and a save is required
+     */
+    private function savePageGroups(Instance $widget, array $sourceGroups): bool
+    {
+        $current = $this->comparablePageGroups($this->getPageGroups($widget->getData('page_groups')));
+        $desired = $this->comparablePageGroups($sourceGroups);
+
+        $widget->setData('page_groups', $this->buildPageGroups($sourceGroups));
+
+        if ($current === $desired) {
+            $this->log->logComment('Widget page_groups unchanged', 1);
+            return false;
+        }
+
+        $this->log->logInfo(sprintf('Widget page_groups = %s', print_r($sourceGroups, true)), 1);
+
+        return true;
+    }
+
+    /**
+     * Reduce a simplified page_groups list (as produced by getPageGroups(), or a
+     * source list) to a canonical, order-insensitive set of comparable rows. The
+     * synthetic page_id is intentionally excluded: stored rows carry the row's
+     * primary key there, not a semantic page id (which, for specific pages, is
+     * encoded in layout_handle and so is already compared).
+     *
+     * @param array $groups
+     * @return string[] sorted JSON rows
+     */
+    private function comparablePageGroups(array $groups): array
+    {
+        $rows = [];
+        foreach ($groups as $group) {
+            if (!is_array($group)) {
+                continue;
+            }
+            $rows[] = (string) json_encode([
+                'page_group' => (string) ($group['page_group'] ?? 'all_pages'),
+                'block' => (string) ($group['block'] ?? ''),
+                'layout_handle' => (string) ($group['layout_handle'] ?? 'default'),
+                'for' => (string) ($group['for'] ?? 'all'),
+                'template' => (string) ($group['template'] ?? ''),
+                'entities' => (string) ($group['entities'] ?? ''),
+            ]);
+        }
+        sort($rows);
+
+        return $rows;
+    }
+
+    /**
      * Export current widget instances into the source format. Refresh mode
      * rewrites only the widgets already tracked in the source file (matched by
      * instance_type + title); full mode dumps every widget instance, optionally
@@ -681,11 +755,11 @@ class Widgets implements ComponentInterface, ExportableComponentInterface
                 continue;
             }
             $built[] = [
-                'page_group' => (string) ($pageGroup['group'] ?? 'all_pages'),
+                'page_group' => (string) ($pageGroup['page_group'] ?? 'all_pages'),
                 'block' => (string) ($pageGroup['block_reference'] ?? ''),
                 'layout_handle' => (string) ($pageGroup['layout_handle'] ?? 'default'),
-                'for' => (string) ($pageGroup['for'] ?? 'all'),
-                'template' => (string) ($pageGroup['template'] ?? ''),
+                'for' => (string) ($pageGroup['page_for'] ?? 'all'),
+                'template' => (string) ($pageGroup['page_template'] ?? ''),
                 'page_id' => (string) ($pageGroup['page_id'] ?? '0'),
                 'entities' => (string) ($pageGroup['entities'] ?? ''),
             ];

--- a/Test/Unit/Component/AttributesTest.php
+++ b/Test/Unit/Component/AttributesTest.php
@@ -142,6 +142,52 @@ class AttributesTest extends TestCase
         $this->assertSame(1, $result->getSkipped());
     }
 
+    public function testAddAttributeOnlyKeysDoNotLogUnmappedError(): void
+    {
+        // The loaded row carries label + input but not the addAttribute-only keys
+        // (sort_order, group, visible) which live in eav_entity_attribute / are
+        // scope-specific. Their absence must not be logged as unmapped.
+        $this->givenExistingAttribute(['frontend_label' => 'Colour', 'frontend_input' => 'text']);
+
+        $logged = $this->captureErrors();
+
+        $this->execute([
+            'colour' => [
+                'label' => 'Colour',
+                'input' => 'text',
+                'sort_order' => 5,
+                'group' => 'General',
+                'visible' => 1,
+            ],
+        ], false, null, ComponentMode::Maintain);
+
+        $unmapped = array_filter(
+            $logged->messages,
+            static fn (string $m): bool => str_contains($m, 'does not exist or is not mapped')
+        );
+        $this->assertSame([], $unmapped);
+    }
+
+    public function testGenuinelyUnknownAbsentKeyStillLogsUnmappedError(): void
+    {
+        // A key that is neither mapped nor a known addAttribute-only key keeps the
+        // diagnostic, so real typos/misconfiguration are still surfaced.
+        $this->givenExistingAttribute(['frontend_label' => 'Colour', 'frontend_input' => 'text']);
+
+        $logged = $this->captureErrors();
+
+        $this->execute([
+            'colour' => ['label' => 'Colour', 'input' => 'text', 'totally_bogus_key' => 1],
+        ], false, null, ComponentMode::Maintain);
+
+        $matches = array_filter(
+            $logged->messages,
+            static fn (string $m): bool => str_contains($m, 'totally_bogus_key')
+                && str_contains($m, 'does not exist or is not mapped')
+        );
+        $this->assertNotEmpty($matches);
+    }
+
     public function testDryRunDoesNotPersist(): void
     {
         $this->eavSetup->method('getAttribute')->willReturn(false);
@@ -308,6 +354,26 @@ class AttributesTest extends TestCase
     private function givenExistingAttribute(array $columns): void
     {
         $this->eavSetup->method('getAttribute')->willReturn(array_merge(['attribute_id' => 5], $columns));
+    }
+
+    /**
+     * Capture every message passed to LoggerInterface::logError(). Returns a
+     * holder whose `messages` array fills (by object reference) as logError()
+     * is called.
+     *
+     * @return object{messages: string[]}
+     */
+    private function captureErrors(): object
+    {
+        $sink = new \stdClass();
+        $sink->messages = [];
+        $this->log->method('logError')->willReturnCallback(
+            static function ($message) use ($sink): void {
+                $sink->messages[] = (string) $message;
+            }
+        );
+
+        return $sink;
     }
 
     private function givenOption(string $value, string $label): Option&MockObject

--- a/Test/Unit/Component/CategoriesTest.php
+++ b/Test/Unit/Component/CategoriesTest.php
@@ -176,6 +176,46 @@ class CategoriesTest extends TestCase
         $this->assertSame(1, $result->getUpdated());
     }
 
+    public function testMaintainModeSkipsUnchangedCategory(): void
+    {
+        $this->givenStoreGroup(1, 2);
+        $root = $this->givenRootCategory(2);
+
+        // An existing category whose tracked fields already match the source.
+        $existing = $this->createMock(Category::class);
+        $existing->method('getId')->willReturn(55);
+        $existing->method('getName')->willReturn('Shirts');
+        $existing->method('getStoreId')->willReturn(0);
+        $existing->method('getData')->willReturnCallback(
+            static fn (string $field) => [
+                'name' => 'Shirts',
+                'is_active' => '1',
+                'url_key' => 'shirts',
+            ][$field] ?? null
+        );
+        $this->givenChildLookupReturns($existing);
+
+        $this->categoryFactory->method('create')->willReturnOnConsecutiveCalls($root, $existing);
+
+        // Unchanged -> the gate skips and the resource model is never touched, so
+        // no URL rewrite regeneration can occur.
+        $this->categoryResource->expects($this->never())->method('save');
+
+        $result = $this->execute([
+            'categories' => [
+                [
+                    'store_group' => 'Main Website Store',
+                    'categories' => [
+                        ['name' => 'Shirts', 'is_active' => '1', 'url_key' => 'shirts'],
+                    ],
+                ],
+            ],
+        ], false, ComponentMode::Maintain);
+
+        $this->assertSame(0, $result->getUpdated());
+        $this->assertSame(1, $result->getSkipped());
+    }
+
     public function testDryRunDoesNotPersist(): void
     {
         $this->givenStoreGroup(1, 2);
@@ -520,6 +560,7 @@ class CategoriesTest extends TestCase
     private function givenChildLookupReturns(Category&MockObject $category): void
     {
         $collection = $this->createMock(CategoryCollection::class);
+        $collection->method('addAttributeToSelect')->willReturnSelf();
         $collection->method('addFieldToFilter')->willReturnSelf();
         $collection->method('setPageSize')->willReturnSelf();
         $collection->method('getFirstItem')->willReturn($category);

--- a/Test/Unit/Component/PagesTest.php
+++ b/Test/Unit/Component/PagesTest.php
@@ -190,6 +190,37 @@ class PagesTest extends TestCase
         $this->assertSame(0, $result->getCreated());
     }
 
+    public function testUnchangedDefaultPageDoesNotReassignStores(): void
+    {
+        // An existing default-scope page already assigned to store [0]. The store
+        // assignment must not be re-set, since doing so marked the model dirty and
+        // produced a phantom "Save page" on every run.
+        $this->givenPageLookup(55);
+
+        $page = $this->getMockBuilder(Page::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setStores'])
+            ->onlyMethods(['getData', 'getId', 'setData', 'setIdentifier', 'unsetData', 'hasDataChanges'])
+            ->getMock();
+        $data = ['title' => 'Same', 'page_layout' => 'empty', 'is_active' => '1', 'store_id' => ['0']];
+        $page->method('getData')->willReturnCallback(static fn (string $key = '') => $data[$key] ?? null);
+        $page->method('getId')->willReturn(55);
+        $page->method('setData')->willReturnSelf();
+        $page->method('unsetData')->willReturnSelf();
+        $page->method('hasDataChanges')->willReturn(false);
+        $this->pageRepository->method('getById')->with(55)->willReturn($page);
+
+        $page->expects($this->never())->method('setStores');
+        $this->pageRepository->expects($this->never())->method('save');
+
+        $result = $this->execute([
+            'about-us' => ['page' => [['title' => 'Same']]],
+        ], false, null, ComponentMode::Maintain);
+
+        $this->assertTrue($result->isSuccessful());
+        $this->assertSame(0, $result->getUpdated());
+    }
+
     public function testCreateModeVersionBumpForcesUpdate(): void
     {
         // Existing page + a newer declared version -> the gate forces an update even

--- a/Test/Unit/Component/TaxRatesTest.php
+++ b/Test/Unit/Component/TaxRatesTest.php
@@ -95,6 +95,35 @@ class TaxRatesTest extends TestCase
         $this->assertTrue($result->isSuccessful());
     }
 
+    public function testImportFileUsesCanonicalMagentoHeader(): void
+    {
+        // Capture the CSV handed to the importer before the component unlinks it.
+        $captured = [];
+        $this->csvImportHandler->expects($this->once())
+            ->method('importFromCsvFile')
+            ->willReturnCallback(static function (array $file) use (&$captured): void {
+                $handle = fopen($file['tmp_name'], 'r');
+                while (($row = fgetcsv($handle, 0, ',', '"', '')) !== false) {
+                    $captured[] = $row;
+                }
+                fclose($handle);
+            });
+
+        $this->execute($this->sampleSource(), false, ComponentMode::Maintain);
+
+        // Row 0 is Magento's canonical header, not the source machine-key header.
+        $this->assertSame(
+            ['Code', 'Country', 'State', 'Zip/Post Code', 'Rate', 'Zip/Post is Range', 'Range From', 'Range To'],
+            $captured[0]
+        );
+        // The data row lines up positionally with that header: postcode at index 3,
+        // rate at index 4 (the order getSortedData emits).
+        $this->assertSame('US-CA-Rate', $captured[1][0]);
+        $this->assertSame('US', $captured[1][1]);
+        $this->assertSame('*', $captured[1][3]);
+        $this->assertSame('8.2500', $captured[1][4]);
+    }
+
     public function testDryRunDoesNotImport(): void
     {
         $this->givenExistingRateCodes([]);

--- a/Test/Unit/Component/TaxRulesTest.php
+++ b/Test/Unit/Component/TaxRulesTest.php
@@ -134,6 +134,42 @@ class TaxRulesTest extends TestCase
         $this->assertSame(1, $result->getUpdated());
     }
 
+    public function testMaintainModeSkipsUnchangedRule(): void
+    {
+        $this->givenRateLookupReturnsId(5);
+        $this->givenTaxClassLookupReturnsId(3);
+
+        // The existence lookup resolves to rule id 42 ...
+        $existing = $this->createMock(Rule::class);
+        $existing->method('getId')->willReturn(42);
+
+        $collection = $this->createMock(\Magento\Tax\Model\ResourceModel\Calculation\Rule\Collection::class);
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getFirstItem')->willReturn($existing);
+
+        // ... and the fully-loaded rule already matches the source row exactly.
+        $loaded = $this->createMock(Rule::class);
+        $loaded->method('getCollection')->willReturn($collection);
+        $loaded->method('getId')->willReturn(42);
+        $loaded->method('getTaxRateIds')->willReturn([5]);
+        $loaded->method('getCustomerTaxClassIds')->willReturn([3]);
+        $loaded->method('getProductTaxClassIds')->willReturn([3]);
+        $loaded->method('getPriority')->willReturn(0);
+        $loaded->method('getCalculateSubtotal')->willReturn(0);
+        $loaded->method('getPosition')->willReturn(1);
+
+        $this->ruleFactory->method('create')->willReturn($loaded);
+        $this->taxRuleResource->method('load')->willReturnSelf();
+
+        // Unchanged -> the gate skips and nothing is re-saved.
+        $this->taxRuleResource->expects($this->never())->method('save');
+
+        $result = $this->execute($this->sourceRows(), false, ComponentMode::Maintain);
+
+        $this->assertSame(0, $result->getUpdated());
+        $this->assertSame(1, $result->getSkipped());
+    }
+
     public function testDryRunDoesNotPersist(): void
     {
         $this->givenRateLookupReturnsId(5);

--- a/Test/Unit/Component/WidgetsTest.php
+++ b/Test/Unit/Component/WidgetsTest.php
@@ -198,6 +198,81 @@ class WidgetsTest extends TestCase
         $this->assertSame(1, $result->getSkipped());
     }
 
+    public function testMaintainModeSkipsWidgetWithUnchangedPageGroups(): void
+    {
+        // The stored widget_instance_page row (block_reference/page_for/page_template
+        // columns + a synthetic page_id) matches the simplified source placement, so
+        // the widget must settle to a skip rather than re-save every run.
+        $existing = $this->givenExistingWidget('Magento\\Cms\\Block\\Widget\\Block', 'Promo');
+        $existing->method('getData')->willReturnCallback(
+            static fn (string $key) => match ($key) {
+                'instance_type' => 'Magento\\Cms\\Block\\Widget\\Block',
+                'title' => 'Promo',
+                'page_groups' => [[
+                    'page_group' => 'all_pages',
+                    'block_reference' => 'content',
+                    'layout_handle' => 'default',
+                    'page_for' => 'all',
+                    'page_template' => '',
+                    'entities' => '',
+                    'page_id' => '26',
+                ]],
+                default => null,
+            }
+        );
+
+        $this->widgetResource->expects($this->never())->method('save');
+
+        $result = $this->execute([
+            [
+                'instance_type' => 'Magento\\Cms\\Block\\Widget\\Block',
+                'title' => 'Promo',
+                'page_groups' => [
+                    ['page_group' => 'all_pages', 'block' => 'content', 'for' => 'all'],
+                ],
+            ],
+        ], false, ComponentMode::Maintain);
+
+        $this->assertSame(0, $result->getUpdated());
+        $this->assertSame(1, $result->getSkipped());
+    }
+
+    public function testMaintainModeUpdatesWidgetWithChangedPageGroups(): void
+    {
+        // The stored placement targets a different block than the source -> re-save.
+        $existing = $this->givenExistingWidget('Magento\\Cms\\Block\\Widget\\Block', 'Promo');
+        $existing->method('getData')->willReturnCallback(
+            static fn (string $key) => match ($key) {
+                'instance_type' => 'Magento\\Cms\\Block\\Widget\\Block',
+                'title' => 'Promo',
+                'page_groups' => [[
+                    'page_group' => 'all_pages',
+                    'block_reference' => 'sidebar',
+                    'layout_handle' => 'default',
+                    'page_for' => 'all',
+                    'page_template' => '',
+                    'entities' => '',
+                    'page_id' => '26',
+                ]],
+                default => null,
+            }
+        );
+        $existing->expects($this->atLeastOnce())->method('setData');
+        $this->widgetResource->expects($this->once())->method('save')->with($existing);
+
+        $result = $this->execute([
+            [
+                'instance_type' => 'Magento\\Cms\\Block\\Widget\\Block',
+                'title' => 'Promo',
+                'page_groups' => [
+                    ['page_group' => 'all_pages', 'block' => 'content', 'for' => 'all'],
+                ],
+            ],
+        ], false, ComponentMode::Maintain);
+
+        $this->assertSame(1, $result->getUpdated());
+    }
+
     public function testDryRunDoesNotPersist(): void
     {
         $this->givenWidgetCollection([]);


### PR DESCRIPTION
Addresses the six gaps reported after the v2 public release. One commit per issue; each ships with unit tests. Verified against a live store (Magento 2.4.7-p3) where applicable.

## Fixes

| Component | Problem | Fix |
|-----------|---------|-----|
| **Categories** | No per-entity diff → re-saved every category every maintain run; the no-op save regenerated URL rewrites and threw `UrlAlreadyExistsException`. | Added `isCategoryUnchanged` diff passed as the gate's `unchanged` flag (loads all attributes on the lookup). Unchanged categories skip the save entirely → no rewrite regeneration. |
| **TaxRules** | No diff → re-imported the rule every run (`updated 1` never settling to 0). | Loads the full rule (rate/class ids live in association tables) and diffs ids + scalars; unchanged rules skip. |
| **Pages** | Unconditional `setStores([0])` (a magic setter) marked the model dirty → phantom "Save page" every run. | Only re-assign stores when the assignment actually differs (or the page is new). |
| **Widgets** | `page_groups` compared the built input form against a value that (a) isn't even loaded on the collection item and (b) uses different stored column names → never equal → forced re-save, which then surfaced "Layout update is invalid". | Hydrate the instance, compare in the simplified source shape (excluding the synthetic page_id), always carry built groups onto the model so an unrelated change can't drop them. Also fixed `getPageGroups` reading wrong stored columns. |
| **TaxRates** | Machine-key header passed to Magento's `CsvImportHandler`; header/data column order disagreed. | Emit Magento's canonical header in the data's actual column order. |
| **Attributes** | Logged "does not exist or is not mapped" for valid addAttribute-only keys (`sort_order`/`group`/`visible`/`position`) it can't read back. | Skip the error for known addAttribute-only keys when absent; still diff them where present; still log genuine typos. |

## Caveats (tested on 2.4.7-p3)
- **TaxRates "Invalid file format"** did not reproduce here (the importer reads positionally, ignoring header names). The fix corrects a genuine latent header/data column-order mismatch and matches the reviewer's recommendation.
- **Widgets "Layout update is invalid"** did not reproduce standalone (saves succeed), but the fix removes the *forced re-save* that — per the reviewer's own chain — was its trigger.

## Verification
- Full module unit suite: **444/444 pass** (the 11 `ExporterTest` errors are a pre-existing env artifact — a root-owned `/tmp/app/etc` blocking a file write — not related to these changes).
- Widgets verified end-to-end against a live store: create → skip → skip, DB unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)