### PR TITLE
v2: fix versioning/existence gaps that overwrote manual edits

### DIFF
--- a/.mage-env.json
+++ b/.mage-env.json
@@ -1,0 +1,9 @@
+{
+  "hash_prefix": "cfg",
+  "mounts": [
+    {
+      "source": "./",
+      "target": "app/code/Magebit/Configurator"
+    }
+  ]
+}

--- a/Component/Attributes.php
+++ b/Component/Attributes.php
@@ -206,6 +206,12 @@ class Attributes implements ComponentInterface, ExportableComponentInterface
 
         if ($this->gate->decide($request)->isSkip()) {
             $this->log->logComment(sprintf('No update for attribute %s (unchanged or create mode).', $attributeCode));
+            // An unchanged attribute already matches the declared version; persist it so
+            // a later manual edit isn't mistaken for a stale entity and overwritten. The
+            // create-mode-protection skip (the attribute differs) deliberately does not.
+            if ($this->attributeExists && !$this->updateAttribute) {
+                $this->gate->commitVersion($request, $dryRun);
+            }
             $result->recordSkipped();
             return;
         }

--- a/Component/Categories.php
+++ b/Component/Categories.php
@@ -204,6 +204,13 @@ class Categories implements ComponentInterface, ExportableComponentInterface
                 $this->log->logComment(
                     sprintf("Skip category '%s' modification (unchanged or create mode)", $categoryValues['name'])
                 );
+                // An unchanged category already matches the declared version; persist it
+                // so a later manual edit isn't mistaken for a stale entity and overwritten.
+                // The create-mode-protection skip ($unchanged === false) deliberately does
+                // not, since YAML was not applied.
+                if ($unchanged) {
+                    $this->gate->commitVersion($request, $dryRun);
+                }
                 $result->recordSkipped();
                 continue;
             }

--- a/Component/Config.php
+++ b/Component/Config.php
@@ -244,7 +244,7 @@ class Config implements ComponentInterface, ExportableComponentInterface
         mixed $value = null,
         int $encrypted = 0,
         ComponentMode $mode = ComponentMode::Maintain,
-        ?string $version = null,
+        int|string|null $version = null,
         bool $dryRun = false,
         ?ComponentResult $result = null
     ): void {
@@ -253,17 +253,28 @@ class Config implements ComponentInterface, ExportableComponentInterface
             $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
             $existingValue = $this->getSetConfigValue($path, $scope, 0);
 
+            // A stored "0"/""/null is still a real value: existence must test for the
+            // row, not the value's truthiness. Using (bool) here made a falsy value look
+            // unset, so the gate dropped create-mode protection and overwrote it.
+            $exists = $existingValue !== false;
+            $unchanged = $exists && $value == $existingValue;
+
             $request = new ReconciliationRequest(
                 self::ALIAS,
                 'global_' . $path,
                 $mode,
-                (bool) $existingValue,
+                $exists,
                 $version ? (int) $version : null,
-                $existingValue !== false && $value == $existingValue
+                $unchanged
             );
 
             if ($this->gate->decide($request)->isSkip()) {
                 $this->log->logComment(sprintf("Global Config Already Has Value: %s = %s", $path, $existingValue));
+                // An unchanged value already matches the declared version; persist it so
+                // a later manual edit isn't mistaken for a stale entity and overwritten.
+                if ($unchanged) {
+                    $this->gate->commitVersion($request, $dryRun);
+                }
                 $result?->recordSkipped();
                 return;
             }
@@ -298,7 +309,7 @@ class Config implements ComponentInterface, ExportableComponentInterface
         string $code,
         int $encrypted = 0,
         ComponentMode $mode = ComponentMode::Maintain,
-        ?string $version = null,
+        int|string|null $version = null,
         bool $dryRun = false,
         ?ComponentResult $result = null
     ): void {
@@ -318,13 +329,19 @@ class Config implements ComponentInterface, ExportableComponentInterface
             // Check existing value, skip if the same
             $existingValue = $this->getSetConfigValue($path, $scope, (int) $website->getId());
 
+            // A stored "0"/""/null is still a real value: existence must test for the
+            // row, not the value's truthiness. Using (bool) here made a falsy value look
+            // unset, so the gate dropped create-mode protection and overwrote it.
+            $exists = $existingValue !== false;
+            $unchanged = $exists && $value == $existingValue;
+
             $request = new ReconciliationRequest(
                 self::ALIAS,
                 'website_' . $website->getId() . '_' . $path,
                 $mode,
-                (bool) $existingValue,
+                $exists,
                 $version ? (int) $version : null,
-                $existingValue !== false && $value == $existingValue
+                $unchanged
             );
 
             if ($this->gate->decide($request)->isSkip()) {
@@ -332,6 +349,11 @@ class Config implements ComponentInterface, ExportableComponentInterface
                     sprintf("Website '%s' Config Already: %s = %s", $code, $path, $existingValue),
                     $logNest
                 );
+                // An unchanged value already matches the declared version; persist it so
+                // a later manual edit isn't mistaken for a stale entity and overwritten.
+                if ($unchanged) {
+                    $this->gate->commitVersion($request, $dryRun);
+                }
                 $result?->recordSkipped();
                 return;
             }
@@ -385,7 +407,7 @@ class Config implements ComponentInterface, ExportableComponentInterface
         string $code,
         int $encrypted = 0,
         ComponentMode $mode = ComponentMode::Maintain,
-        ?string $version = null,
+        int|string|null $version = null,
         bool $dryRun = false,
         ?ComponentResult $result = null
     ): void {
@@ -404,13 +426,19 @@ class Config implements ComponentInterface, ExportableComponentInterface
             // Check existing value, skip if the same
             $existingValue = $this->getSetConfigValue($path, $scope, (int) $storeView->getId());
 
+            // A stored "0"/""/null is still a real value: existence must test for the
+            // row, not the value's truthiness. Using (bool) here made a falsy value look
+            // unset, so the gate dropped create-mode protection and overwrote it.
+            $exists = $existingValue !== false;
+            $unchanged = $exists && $value == $existingValue;
+
             $request = new ReconciliationRequest(
                 self::ALIAS,
                 'store_' . $storeView->getId() . '_' . $path,
                 $mode,
-                (bool) $existingValue,
+                $exists,
                 $version ? (int) $version : null,
-                $existingValue !== false && $value == $existingValue
+                $unchanged
             );
 
             if ($this->gate->decide($request)->isSkip()) {
@@ -418,6 +446,11 @@ class Config implements ComponentInterface, ExportableComponentInterface
                     sprintf("Store '%s' Config Already: %s = %s", $code, $path, $existingValue),
                     $logNest
                 );
+                // An unchanged value already matches the declared version; persist it so
+                // a later manual edit isn't mistaken for a stale entity and overwritten.
+                if ($unchanged) {
+                    $this->gate->commitVersion($request, $dryRun);
+                }
                 $result?->recordSkipped();
                 return;
             }

--- a/Component/HyvaBlocks.php
+++ b/Component/HyvaBlocks.php
@@ -150,6 +150,10 @@ class HyvaBlocks implements ComponentInterface, ExportableComponentInterface
         $existing = $this->loadExisting($cmsBlockId);
         if ($existing !== false && $this->isUnchanged($existing, $content, $isLiveview)) {
             $this->log->logComment(sprintf('Hyvä block "%s" already up to date.', $identifier));
+            // Unchanged block: persist its version so a later manual edit isn't mistaken
+            // for a stale entity and overwritten. The create-mode-protection skip returned
+            // earlier, so this path is only reached for a genuinely unchanged block.
+            $this->gate->commitVersion($request, $dryRun);
             $result->recordSkipped();
             return;
         }

--- a/Component/HyvaPages.php
+++ b/Component/HyvaPages.php
@@ -133,6 +133,12 @@ class HyvaPages implements ComponentInterface, ExportableComponentInterface
         $outcome = $this->gate->decide($request);
         if ($outcome->isSkip()) {
             $this->log->logComment(sprintf('Hyvä page "%s" skipped (unchanged or create mode).', $identifier));
+            // An unchanged page already matches the declared version; persist it so a
+            // later manual edit isn't mistaken for a stale entity and overwritten. The
+            // create-mode-protection skip ($unchanged === false) deliberately does not.
+            if ($unchanged) {
+                $this->gate->commitVersion($request, $context->isDryRun());
+            }
             $result->recordSkipped();
             return;
         }

--- a/Component/Widgets.php
+++ b/Component/Widgets.php
@@ -180,6 +180,10 @@ class Widgets implements ComponentInterface, ExportableComponentInterface
             }
 
             if (!$canSave) {
+                // Unchanged existing widget: persist its version so a later manual edit
+                // isn't mistaken for a stale entity and overwritten. A new widget always
+                // has $canSave = true, and the create-mode-protection skip returned earlier.
+                $this->gate->commitVersion($request, $dryRun);
                 $result->recordSkipped();
                 return;
             }

--- a/Test/Unit/Component/ConfigTest.php
+++ b/Test/Unit/Component/ConfigTest.php
@@ -42,6 +42,7 @@ class ConfigTest extends TestCase
     private StoreFactory&MockObject $storeFactory;
     private LoggerInterface&MockObject $log;
     private ConfigCollectionFactory&MockObject $configValueFactory;
+    private VersionManagementInterface&MockObject $versionManagement;
     private Config $component;
 
     protected function setUp(): void
@@ -72,9 +73,9 @@ class ConfigTest extends TestCase
         $this->initialConfig->method('getMetadata')->willReturn([]);
 
         // Real gate over a version store that always reports "not newer".
-        $versionManagement = $this->createMock(VersionManagementInterface::class);
-        $versionManagement->method('isNewVersion')->willReturn(false);
-        $gate = new ReconciliationGate($versionManagement, $this->log);
+        $this->versionManagement = $this->createMock(VersionManagementInterface::class);
+        $this->versionManagement->method('isNewVersion')->willReturn(false);
+        $gate = new ReconciliationGate($this->versionManagement, $this->log);
 
         $this->component = new Config(
             $this->configResource,
@@ -157,6 +158,64 @@ class ConfigTest extends TestCase
                 ['path' => 'general/store/name', 'value' => 'Acme'],
             ],
         ], false, ComponentMode::Maintain);
+
+        $this->assertSame(1, $result->getSkipped());
+    }
+
+    public function testCreateModeProtectsExistingFalsyValue(): void
+    {
+        // Regression: a stored "0" is a real value. Existence must not be measured by
+        // the value's truthiness (the old `(bool) $existingValue` made "0" look unset,
+        // so create mode "created" over it instead of protecting the manual change).
+        $this->givenLookupCollection('0');
+
+        $this->configResource->expects($this->never())->method('saveConfig');
+
+        $result = $this->execute([
+            'global' => [
+                ['path' => 'checkout/options/enable_agreements', 'value' => '1'],
+            ],
+        ]);
+
+        $this->assertSame(0, $result->getCreated());
+        $this->assertSame(1, $result->getSkipped());
+    }
+
+    public function testCommitsVersionWhenSkippingUnchangedValue(): void
+    {
+        // Regression: an unchanged value must still have its version persisted, so a
+        // later manual edit isn't seen as a stale (version 0) entity and overwritten.
+        // The save is skipped, but the version is committed.
+        $this->givenLookupCollection('Acme');
+
+        $this->configResource->expects($this->never())->method('saveConfig');
+        $this->versionManagement->expects($this->once())
+            ->method('setVersion')
+            ->with('config_global_general/store/name', 2);
+
+        $result = $this->execute([
+            'global' => [
+                ['path' => 'general/store/name', 'value' => 'Acme', 'version' => 2],
+            ],
+        ], false, ComponentMode::Maintain);
+
+        $this->assertSame(1, $result->getSkipped());
+    }
+
+    public function testDoesNotCommitVersionWhenProtectingChangedValueInCreateMode(): void
+    {
+        // The create-mode-protection skip (existing value differs, no version bump) must
+        // NOT bump the stored version: the YAML was deliberately not applied.
+        $this->givenLookupCollection('Old Name');
+
+        $this->configResource->expects($this->never())->method('saveConfig');
+        $this->versionManagement->expects($this->never())->method('setVersion');
+
+        $result = $this->execute([
+            'global' => [
+                ['path' => 'general/store/name', 'value' => 'New Name', 'version' => 2],
+            ],
+        ]);
 
         $this->assertSame(1, $result->getSkipped());
     }
@@ -426,9 +485,9 @@ class ConfigTest extends TestCase
      */
     private function rebuildComponent(): void
     {
-        $versionManagement = $this->createMock(VersionManagementInterface::class);
-        $versionManagement->method('isNewVersion')->willReturn(false);
-        $gate = new ReconciliationGate($versionManagement, $this->log);
+        $this->versionManagement = $this->createMock(VersionManagementInterface::class);
+        $this->versionManagement->method('isNewVersion')->willReturn(false);
+        $gate = new ReconciliationGate($this->versionManagement, $this->log);
 
         $this->component = new Config(
             $this->configResource,

--- a/Test/Unit/Component/WidgetsTest.php
+++ b/Test/Unit/Component/WidgetsTest.php
@@ -49,6 +49,7 @@ class WidgetsTest extends TestCase
     private BlockRepositoryInterface&MockObject $blockRepository;
     private SearchCriteriaBuilder&MockObject $criteriaBuilder;
     private WidgetInstanceResource&MockObject $widgetResource;
+    private VersionManagementInterface&MockObject $versionManagement;
     private Widgets $component;
 
     protected function setUp(): void
@@ -83,9 +84,9 @@ class WidgetsTest extends TestCase
         );
 
         // Real gate over a version store that always reports "not newer".
-        $versionManagement = $this->createMock(VersionManagementInterface::class);
-        $versionManagement->method('isNewVersion')->willReturn(false);
-        $gate = new ReconciliationGate($versionManagement, $this->log);
+        $this->versionManagement = $this->createMock(VersionManagementInterface::class);
+        $this->versionManagement->method('isNewVersion')->willReturn(false);
+        $gate = new ReconciliationGate($this->versionManagement, $this->log);
 
         $this->component = new Widgets(
             $this->widgetCollection,
@@ -191,6 +192,37 @@ class WidgetsTest extends TestCase
                 'instance_type' => 'Magento\\Banner\\Block\\Widget\\Banner',
                 'title' => 'Promo Banner',
                 'css_class' => 'same-css',
+            ],
+        ], false, ComponentMode::Maintain);
+
+        $this->assertSame(0, $result->getUpdated());
+        $this->assertSame(1, $result->getSkipped());
+    }
+
+    public function testCommitsVersionWhenSkippingUnchangedWidget(): void
+    {
+        // Regression: an unchanged widget must still have its version persisted, so a
+        // later manual edit isn't seen as a stale (version 0) entity and overwritten by
+        // demo YAML. The save is skipped (nothing changed), but the version is committed.
+        $existing = $this->givenExistingWidget('Magento\\Banner\\Block\\Widget\\Banner', 'Promo Banner');
+        $existing->method('getData')->willReturnCallback(
+            static fn (string $key): ?string => match ($key) {
+                'instance_type' => 'Magento\\Banner\\Block\\Widget\\Banner',
+                'title' => 'Promo Banner',
+                default => null,
+            }
+        );
+
+        $this->widgetResource->expects($this->never())->method('save');
+        $this->versionManagement->expects($this->once())
+            ->method('setVersion')
+            ->with('widgets_Magento\\Banner\\Block\\Widget\\Banner|Promo Banner', 1);
+
+        $result = $this->execute([
+            [
+                'instance_type' => 'Magento\\Banner\\Block\\Widget\\Banner',
+                'title' => 'Promo Banner',
+                'version' => 1,
             ],
         ], false, ComponentMode::Maintain);
 


### PR DESCRIPTION
Fixes for two issues found on the Verdex rollout (reported by Deniss Simonaits over Slack), plus a related still-open Config typing bug surfaced while adding regression coverage.

## 1. Config existence test used value truthiness (data loss)
`Component/Config.php` measured existence with `(bool) $existingValue`, so a stored `"0"` / `""` / `null` looked **unset**. The reconciliation gate then dropped create-mode protection and overwrote a manually-set falsy value (his example: `checkout/options/enable_agreements = 0`). Now tests `$existingValue !== false` in all three scopes (global/website/store).

## 2. Version not persisted on the unchanged path (systemic, data loss)
Several components skipped an *unchanged* entity and returned **before** `commitVersion()`, leaving `stored < yaml` indefinitely. A later admin edit then read as a stale (version 0) entity and was overwritten by outdated YAML — this is what reverted Verdex's manually-edited Team Grid widget to demo content.

The version is now committed on the **unchanged** skip — but deliberately **not** on the create-mode-protection skip (which must not bump the stored version) — in: **Config, Categories, HyvaPages, Attributes, Widgets, HyvaBlocks**. This mirrors the already-correct pattern in `Blocks`/`Pages` (commit after the field diff). `CustomerGroups`/`TaxRules` pass `version=null` and are unaffected.

> The one-time v1→v2 version-key rename that caused the original Verdex overwrite is unrecoverable by code; this change closes the recurrence window going forward.

## 3. Config `?string $version` TypeError (bonus)
`setGlobalConfig()`/`setWebsiteConfig()`/`setStoreConfig()` declared `?string $version`, which `TypeError`d on an integer YAML version (`version: 2`) and aborted the whole config component in production mode. Now `int|string|null`, consistent with the other components. (This was an earlier report of Deniss's that was never fixed; my version-commit test surfaced it.)

## Testing
- New mage-env testground (`.mage-env.json`, separate commit): 2.4.8-p4 / PHP 8.4, module live-mounted.
- Added regression tests: falsy-value protection, version-commit-on-unchanged, no-commit-on-create-mode-protection (`ConfigTest`), and unchanged-widget version commit (`WidgetsTest`).
- **Full unit suite: 459 passing.** phpcs: 0 new errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)